### PR TITLE
Link libgcc.a to support Android 10+

### DIFF
--- a/Sdk.zig
+++ b/Sdk.zig
@@ -574,6 +574,7 @@ pub fn compileAppLibrary(
     const TargetConfig = struct {
         lib_dir: []const u8,
         include_dir: []const u8,
+        libgcc_dir: []const u8,
         out_dir: []const u8,
         target: std.zig.CrossTarget,
     };
@@ -581,24 +582,28 @@ pub fn compileAppLibrary(
     const config: TargetConfig = switch (target) {
         .aarch64 => TargetConfig{
             .lib_dir = "arch-arm64/usr/lib",
+            .libgcc_dir = "aarch64-linux-android-4.9",
             .include_dir = "aarch64-linux-android",
             .out_dir = "arm64-v8a",
             .target = zig_targets.aarch64,
         },
         .arm => TargetConfig{
             .lib_dir = "arch-arm/usr/lib",
+            .libgcc_dir = "arm-linux-androideabi-4.9",
             .include_dir = "arm-linux-androideabi",
             .out_dir = "armeabi",
             .target = zig_targets.arm,
         },
         .x86 => TargetConfig{
             .lib_dir = "arch-x86/usr/lib",
+            .libgcc_dir = "x86-4.9",
             .include_dir = "i686-linux-android",
             .out_dir = "x86",
             .target = zig_targets.x86,
         },
         .x86_64 => TargetConfig{
             .lib_dir = "arch-x86_64/usr/lib64",
+            .libgcc_dir = "x86_64-4.9",
             .include_dir = "x86_64-linux-android",
             .out_dir = "x86_64",
             .target = zig_targets.x86_64,
@@ -612,8 +617,14 @@ pub fn compileAppLibrary(
 
     const lib_dir = std.fs.path.resolve(sdk.b.allocator, &[_][]const u8{ lib_dir_root, config.lib_dir }) catch unreachable;
 
+    const libgcc_path = sdk.b.fmt(
+        "{s}/toolchains/{s}/prebuilt/windows-x86_64/lib/gcc/{s}/4.9.x/libgcc.a",
+        .{ ndk_root, config.libgcc_dir, config.include_dir },
+    );
+
     exe.setTarget(config.target);
     exe.addLibPath(lib_dir);
+    exe.addObjectFile(libgcc_path);
     exe.addIncludeDir(std.fs.path.resolve(sdk.b.allocator, &[_][]const u8{ include_dir, config.include_dir }) catch unreachable);
 
     exe.setLibCFile(sdk.createLibCFile(config.out_dir, include_dir, include_dir, lib_dir) catch unreachable);

--- a/Sdk.zig
+++ b/Sdk.zig
@@ -617,9 +617,16 @@ pub fn compileAppLibrary(
 
     const lib_dir = std.fs.path.resolve(sdk.b.allocator, &[_][]const u8{ lib_dir_root, config.lib_dir }) catch unreachable;
 
+    const prebuilt_dir = switch (builtin.os.tag) {
+        .windows => "windows",
+        .linux => "linux",
+        .macos => "darwin",
+        else => unreachable,
+    };
+
     const libgcc_path = sdk.b.fmt(
-        "{s}/toolchains/{s}/prebuilt/windows-x86_64/lib/gcc/{s}/4.9.x/libgcc.a",
-        .{ ndk_root, config.libgcc_dir, config.include_dir },
+        "{s}/toolchains/{s}/prebuilt/{s}-x86_64/lib/gcc/{s}/4.9.x/libgcc.a",
+        .{ ndk_root, config.libgcc_dir, prebuilt_dir, config.include_dir },
     );
 
     exe.setTarget(config.target);


### PR DESCRIPTION
Running the master branch on an emulator with API level 30 (Android 11) produces the following error:
`NativeActivity: NativeActivity LoadNativeLibrary("/.../lib/x86_64/libzig-app-template.so") failed: dlopen failed: cannot locate symbol "__emutls_get_address" referenced by ".../lib/x86_64/libzig-app-template.so"...`

Seems like Android 10 [brought changes to ThreadLocalStorage](https://developer.android.com/about/versions/10/features#elf-tls), requiring to pull the symbol from libgcc or get Zig compiler_rt to work on Android.

This change links in libgcc. Verified on emulators for Android 9 and 11, as well as on physical OnePlus 8 Pro with Android 11.