### PR TITLE
Adds support for Audio

### DIFF
--- a/Sdk.zig
+++ b/Sdk.zig
@@ -186,6 +186,8 @@ pub const AppConfig = struct {
         //"android.permission.SET_RELEASE_APP",
         //"android.permission.RECORD_AUDIO",
     },
+
+    libraries: []const []const u8 = &app_libs,
 };
 
 /// One of the legal targets android can be built for.
@@ -730,7 +732,7 @@ pub fn compileAppLibrary(
     exe.defineCMacro("ANDROID", null);
 
     exe.linkLibC();
-    for (app_libs) |lib| {
+    for (app_config.libraries) |lib| {
         exe.linkSystemLibraryName(lib);
     }
 
@@ -991,7 +993,7 @@ const zig_targets = struct {
 };
 
 const app_libs = [_][]const u8{
-    "GLESv2", "EGL", "android", "log",
+    "GLESv2", "EGL", "android", "log", "aaudio"
 };
 
 const BuildOptionStep = struct {

--- a/Sdk.zig
+++ b/Sdk.zig
@@ -179,6 +179,12 @@ pub const AppConfig = struct {
     /// This is usually relevant for games.
     fullscreen: bool = false,
 
+    /// If true, the app will be compiled with the AAudio library.
+    aaudio: bool = false,
+
+    /// If true, the app will be compiled with the OpenSL library
+    opensl: bool = true,
+
     /// One or more asset directories. Each directory will be added into the app assets.
     asset_directories: []const []const u8 = &[_][]const u8{},
 
@@ -552,6 +558,8 @@ pub fn createApp(
     build_options.add([]const u8, "app_name", app_config.app_name);
     build_options.add(u16, "android_sdk_version", sdk_version_int);
     build_options.add(bool, "fullscreen", app_config.fullscreen);
+    build_options.add(bool, "enable_aaudio", app_config.aaudio);
+    build_options.add(bool, "enable_opensl", app_config.opensl);
 
     const align_step = sdk.alignApk(unaligned_apk_file, apk_file);
 

--- a/build.zig
+++ b/build.zig
@@ -49,7 +49,7 @@ pub fn build(b: *std.build.Builder) !void {
 
         // This is a list of native android apis to link against.
         .libraries = &[_][]const u8{
-            "GLESv2", "EGL", "android", "log", "aaudio",
+            "GLESv2", "EGL", "android", "log", "aaudio", "OpenSLES"
         },
     };
 

--- a/build.zig
+++ b/build.zig
@@ -49,7 +49,7 @@ pub fn build(b: *std.build.Builder) !void {
 
         // This is a list of native android apis to link against.
         .libraries = &[_][]const u8{
-            "GLESv2", "EGL", "android", "log", "aaudio", "OpenSLES"
+            "GLESv2", "EGL", "android", "log", "OpenSLES"
         },
     };
 

--- a/build.zig
+++ b/build.zig
@@ -46,6 +46,11 @@ pub fn build(b: *std.build.Builder) !void {
             "android.permission.SET_RELEASE_APP",
             //"android.permission.RECORD_AUDIO",
         },
+
+        // This is a list of native android apis to link against.
+        .libraries = &[_][]const u8{
+            "GLESv2", "EGL", "android", "log", "aaudio",
+        },
     };
 
     const app = sdk.createApp(

--- a/example/audio.zig
+++ b/example/audio.zig
@@ -1,0 +1,147 @@
+const std = @import("std");
+
+const android = @import("android");
+
+const JNI = android.JNI;
+const c = android.egl.c;
+
+const app_log = std.log.scoped(.app);
+
+const Oscillator = struct {
+    isWaveOn: bool,
+    phase: f64 = 0.0,
+    phaseIncrement: f64 = 0,
+    frequency: f64 = 440,
+    amplitude: f64 = 0.1,
+    fn setWaveOn(self: *@This(), isWaveOn: bool) void {
+        @atomicStore(bool, &self.isWaveOn, isWaveOn, .SeqCst);
+    }
+    fn setSampleRate(self: *@This(), sample_rate: i32) void {
+        self.phaseIncrement = (std.math.tau * self.frequency) / @intToFloat(f64, sample_rate);
+    }
+    fn render(self: *@This(), audio_data: []f32) void {
+        if (!@atomicLoad(bool, &self.isWaveOn, .SeqCst)) self.phase = 0;
+
+        for (audio_data) |*frame| {
+            if (@atomicLoad(bool, &self.isWaveOn, .SeqCst)) {
+                frame.* += @floatCast(f32, std.math.sin(self.phase) * self.amplitude);
+                self.phase += self.phaseIncrement;
+                if (self.phase > std.math.tau) self.phase -= std.math.tau;
+            }
+        }
+    }
+};
+
+pub const AudioEngine = struct {
+    oscillators: [10]Oscillator = undefined,
+    stream: ?*c.AAudioStream = null,
+
+    const buffer_size_in_bursts = 2;
+
+    fn dataCallback(
+        stream: ?*c.AAudioStream,
+        user_data: ?*anyopaque,
+        audio_data: ?*anyopaque,
+        num_frames: i32,
+    ) callconv(.C) c.aaudio_data_callback_result_t {
+        _ = stream;
+        const audio_engine = @ptrCast(*AudioEngine, @alignCast(@alignOf(AudioEngine), user_data.?));
+        const audio_slice = @ptrCast([*]f32, @alignCast(@alignOf(f32), audio_data.?))[0..@intCast(usize, num_frames)];
+        for (audio_slice) |*frame| {
+            frame.* = 0;
+        }
+        for (audio_engine.oscillators) |*oscillator| {
+            oscillator.render(audio_slice);
+        }
+        return c.AAUDIO_CALLBACK_RESULT_CONTINUE;
+    }
+
+    fn errorCallback(
+        stream: ?*c.AAudioStream,
+        user_data: ?*anyopaque,
+        err: c.aaudio_result_t,
+    ) callconv(.C) void {
+        _ = stream;
+        if (err == c.AAUDIO_ERROR_DISCONNECTED) {
+            const self = @ptrCast(*AudioEngine, @alignCast(@alignOf(AudioEngine), user_data.?));
+            _ = std.Thread.spawn(.{}, restart, .{self}) catch {
+                app_log.err("Couldn't spawn thread", .{});
+            };
+        }
+    }
+
+    pub fn start(self: *@This()) bool {
+        var stream_builder: ?*c.AAudioStreamBuilder = null;
+        _ = c.AAudio_createStreamBuilder(&stream_builder);
+        defer _ = c.AAudioStreamBuilder_delete(stream_builder);
+
+        c.AAudioStreamBuilder_setFormat(stream_builder, c.AAUDIO_FORMAT_PCM_FLOAT);
+        c.AAudioStreamBuilder_setChannelCount(stream_builder, 1);
+        c.AAudioStreamBuilder_setPerformanceMode(stream_builder, c.AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
+        c.AAudioStreamBuilder_setDataCallback(stream_builder, dataCallback, self);
+        c.AAudioStreamBuilder_setErrorCallback(stream_builder, errorCallback, self);
+
+        {
+            const result = c.AAudioStreamBuilder_openStream(stream_builder, &self.stream);
+            if (result != c.AAUDIO_OK) {
+                app_log.err("Error opening stream {s}", .{c.AAudio_convertResultToText(result)});
+                return false;
+            }
+        }
+
+        const sample_rate = c.AAudioStream_getSampleRate(self.stream);
+        for (self.oscillators) |*oscillator, index| {
+            oscillator.* = Oscillator{
+                .isWaveOn = false,
+                .frequency = midiToFreq(49 + index * 3),
+                .amplitude = dBToAmplitude(-@intToFloat(f64, index) - 11),
+            };
+            oscillator.setSampleRate(sample_rate);
+        }
+
+        _ = c.AAudioStream_setBufferSizeInFrames(self.stream, c.AAudioStream_getFramesPerBurst(self.stream) * buffer_size_in_bursts);
+
+        {
+            const result = c.AAudioStream_requestStart(self.stream);
+            if (result != c.AAUDIO_OK) {
+                app_log.err("Error starting stream {s}", .{c.AAudio_convertResultToText(result)});
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    var restartingLock = std.Thread.Mutex{};
+    pub fn restart(self: *@This()) void {
+        if (restartingLock.tryLock()) {
+            self.stop();
+            _ = self.start();
+            restartingLock.unlock();
+        }
+    }
+
+    pub fn stop(self: *@This()) void {
+        if (self.stream) |stream| {
+            _ = c.AAudioStream_requestStop(stream);
+            _ = c.AAudioStream_close(stream);
+        }
+    }
+
+    pub fn setToneOn(self: *@This(), which: usize, isToneOn: bool) void {
+        // if (which >= self.oscillators.len) return;
+        self.oscillators[which].setWaveOn(isToneOn);
+    }
+};
+
+fn midiToFreq(note: usize) f64 {
+    return std.math.pow(f64, 2, (@intToFloat(f64, note) - 49) / 12) * 440;
+}
+
+fn amplitudeTodB(amplitude: f64) f64 {
+    return 20.0 * std.math.log10(amplitude);
+}
+
+fn dBToAmplitude(dB: f64) f64 {
+    return std.math.pow(f64, 10.0, dB / 20.0);
+}

--- a/example/audio.zig
+++ b/example/audio.zig
@@ -5,7 +5,7 @@ const android = @import("android");
 const JNI = android.JNI;
 const c = android.egl.c;
 
-const app_log = std.log.scoped(.app);
+const app_log = std.log.scoped(.audio);
 
 const Oscillator = struct {
     isWaveOn: bool,
@@ -145,3 +145,486 @@ fn amplitudeTodB(amplitude: f64) f64 {
 fn dBToAmplitude(dB: f64) f64 {
     return std.math.pow(f64, 10.0, dB / 20.0);
 }
+
+// OpenSLES support
+pub const OpenSL = struct {
+    var init_sl_counter: usize = 0;
+    var engine_object: c.SLObjectItf = undefined;
+    var engine: c.SLEngineItf = undefined;
+
+    var output_mix: c.SLObjectItf = undefined;
+    // var volume_itf: c.SLVolumeItf = undefined;
+
+    var player: c.SLObjectItf = undefined;
+    var play_itf: c.SLPlayItf = undefined;
+    var buffer_queue_itf: c.SLBufferQueueItf = undefined;
+    var state: c.SLBufferQueueState = undefined;
+
+    var audio_sink: c.SLDataSink = undefined;
+    var locator_outputmix: c.SLDataLocator_OutputMix = undefined;
+
+    var audio_source: c.SLDataSource = undefined;
+    var buffer_queue: c.SLDataLocator_BufferQueue = undefined;
+    var pcm: c.SLDataFormat_PCM = undefined;
+
+    // Local storage for audio data in 16 bit words
+    const audio_data_storage_size = 4096;
+    // Audio data buffer size in 16 bit words. 8 data segments are used in this simple example.
+    const audio_data_buffer_size = audio_data_storage_size / 8;
+
+    // Local storage for audio data
+    var pcm_data: [audio_data_storage_size]c.SLint16 = undefined;
+
+    const CallbackContext = struct {
+        play_itf: c.SLPlayItf,
+        /// Base buffer of local audio data storage
+        data_base: []c.SLint16,
+        /// Current location in local audio data storage
+        data_index: usize,
+        phase: f64 = 0.0,
+        phaseIncrement: f64 = 0,
+        frequency: f64 = 440,
+        amplitude: f64 = 0.1,
+    };
+
+    pub fn bufferQueueCallback(queue_itf: c.SLBufferQueueItf, user_data: ?*anyopaque) callconv(.C) void {
+        app_log.info("buffer queue callback", .{});
+        var context = @ptrCast(*CallbackContext, @alignCast(@alignOf(CallbackContext), user_data));
+        if (context.data_index < context.data_base.len) {
+            var buffer = context.data_base[context.data_index..audio_data_storage_size];
+            for (buffer) |*sample| {
+                sample.* = 0;
+                sample.* +|= @floatToInt(i16, (std.math.sin(context.phase) * context.amplitude));
+                context.phase += context.phaseIncrement;
+                if (context.phase > std.math.tau) context.phase -= std.math.tau;
+            }
+            checkResult(queue_itf.*.*.Enqueue.?(queue_itf, @ptrCast(*anyopaque, buffer.ptr), @intCast(c.SLuint32, 2 * buffer.len))) catch |e| {
+                app_log.err("Error enqueueing buffer! {s}", .{@errorName(e)});
+            };
+            context.data_index += audio_data_buffer_size;
+        }
+    }
+
+    fn iidEq(iid1: c.SLInterfaceID, iid2: c.SLInterfaceID) bool {
+        return iid1.*.time_low == iid2.*.time_low and
+            iid1.*.time_mid == iid2.*.time_mid and
+            iid1.*.time_hi_and_version == iid2.*.time_hi_and_version and
+            iid1.*.clock_seq == iid2.*.clock_seq and
+            iid1.*.time_mid == iid2.*.time_mid and
+            std.mem.eql(u8, &iid1.*.node, &iid2.*.node);
+    }
+
+    const InterfaceID = enum {
+        AudioIODeviceCapabilities,
+        Led,
+        Vibra,
+        MetadataExtraction,
+        MetadataTraversal,
+        DynamicSource,
+        OutputMix,
+        Play,
+        PrefetchStatus,
+        PlaybackRate,
+        Seek,
+        Record,
+        Equalizer,
+        Volume,
+        DeviceVolume,
+        Object,
+        BufferQueue,
+        PresetReverb,
+        EnvironmentalReverb,
+        EffectSend,
+        _3DGrouping,
+        _3DCommit,
+        _3DLocation,
+        _3DDoppler,
+        _3DSource,
+        _3DMacroscopic,
+        MuteSolo,
+        DynamicInterfaceManagement,
+        MidiMessage,
+        MidiTempo,
+        MidiMuteSolo,
+        MidiTime,
+        AudioDecoderCapabilities,
+        AudioEncoder,
+        AudioEncoderCapabilities,
+        BassBoost,
+        Pitch,
+        RatePitch,
+        Virtualizer,
+        Visualization,
+        Engine,
+        EngineCapabilities,
+        ThreadSync,
+        AndroidEffect,
+        AndroidEffectSend,
+        AndroidConfiguration,
+        AndroidSimpleBufferQueue,
+        AndroidBufferQueueSource,
+        AndroidAcousticEchoCancellation,
+        AndroidAutomaticGainControl,
+        AndroidNoiseSuppresssion,
+        fn fromIid(iid: c.SLInterfaceID) ?InterfaceID {
+            if (iidEq(iid, c.SL_IID_NULL)) return null;
+            if (iidEq(iid, c.SL_IID_AUDIOIODEVICECAPABILITIES)) return .AudioIODeviceCapabilities;
+            if (iidEq(iid, c.SL_IID_LED)) return .Led;
+            if (iidEq(iid, c.SL_IID_VIBRA)) return .Vibra;
+            if (iidEq(iid, c.SL_IID_METADATAEXTRACTION)) return .MetadataExtraction;
+            if (iidEq(iid, c.SL_IID_METADATATRAVERSAL)) return .MetadataTraversal;
+            if (iidEq(iid, c.SL_IID_DYNAMICSOURCE)) return .DynamicSource;
+            if (iidEq(iid, c.SL_IID_OUTPUTMIX)) return .OutputMix;
+            if (iidEq(iid, c.SL_IID_PLAY)) return .Play;
+            if (iidEq(iid, c.SL_IID_PREFETCHSTATUS)) return .PrefetchStatus;
+            if (iidEq(iid, c.SL_IID_PLAYBACKRATE)) return .PlaybackRate;
+            if (iidEq(iid, c.SL_IID_SEEK)) return .Seek;
+            if (iidEq(iid, c.SL_IID_RECORD)) return .Record;
+            if (iidEq(iid, c.SL_IID_EQUALIZER)) return .Equalizer;
+            if (iidEq(iid, c.SL_IID_VOLUME)) return .Volume;
+            if (iidEq(iid, c.SL_IID_DEVICEVOLUME)) return .DeviceVolume;
+            if (iidEq(iid, c.SL_IID_OBJECT)) return .Object;
+            if (iidEq(iid, c.SL_IID_BUFFERQUEUE)) return .BufferQueue;
+            if (iidEq(iid, c.SL_IID_PRESETREVERB)) return .PresetReverb;
+            if (iidEq(iid, c.SL_IID_ENVIRONMENTALREVERB)) return .EnvironmentalReverb;
+            if (iidEq(iid, c.SL_IID_EFFECTSEND)) return .EffectSend;
+            if (iidEq(iid, c.SL_IID_3DGROUPING)) return ._3DGrouping;
+            if (iidEq(iid, c.SL_IID_3DCOMMIT)) return ._3DCommit;
+            if (iidEq(iid, c.SL_IID_3DLOCATION)) return ._3DLocation;
+            if (iidEq(iid, c.SL_IID_3DDOPPLER)) return ._3DDoppler;
+            if (iidEq(iid, c.SL_IID_3DSOURCE)) return ._3DSource;
+            if (iidEq(iid, c.SL_IID_3DMACROSCOPIC)) return ._3DMacroscopic;
+            if (iidEq(iid, c.SL_IID_MUTESOLO)) return .MuteSolo;
+            if (iidEq(iid, c.SL_IID_DYNAMICINTERFACEMANAGEMENT)) return .DynamicInterfaceManagement;
+            if (iidEq(iid, c.SL_IID_MIDIMESSAGE)) return .MidiMessage;
+            if (iidEq(iid, c.SL_IID_MIDITEMPO)) return .MidiTempo;
+            if (iidEq(iid, c.SL_IID_MIDIMUTESOLO)) return .MidiMuteSolo;
+            if (iidEq(iid, c.SL_IID_MIDITIME)) return .MidiTime;
+            if (iidEq(iid, c.SL_IID_AUDIODECODERCAPABILITIES)) return .AudioDecoderCapabilities;
+            if (iidEq(iid, c.SL_IID_AUDIOENCODER)) return .AudioEncoder;
+            if (iidEq(iid, c.SL_IID_AUDIOENCODERCAPABILITIES)) return .AudioEncoderCapabilities;
+            if (iidEq(iid, c.SL_IID_BASSBOOST)) return .BassBoost;
+            if (iidEq(iid, c.SL_IID_PITCH)) return .Pitch;
+            if (iidEq(iid, c.SL_IID_RATEPITCH)) return .RatePitch;
+            if (iidEq(iid, c.SL_IID_VIRTUALIZER)) return .Virtualizer;
+            if (iidEq(iid, c.SL_IID_VISUALIZATION)) return .Visualization;
+            if (iidEq(iid, c.SL_IID_ENGINE)) return .Engine;
+            if (iidEq(iid, c.SL_IID_ENGINECAPABILITIES)) return .EngineCapabilities;
+            if (iidEq(iid, c.SL_IID_ANDROIDEFFECT)) return .AndroidEffect;
+            if (iidEq(iid, c.SL_IID_ANDROIDEFFECTSEND)) return .AndroidEffectSend;
+            if (iidEq(iid, c.SL_IID_ANDROIDCONFIGURATION)) return .AndroidConfiguration;
+            if (iidEq(iid, c.SL_IID_ANDROIDSIMPLEBUFFERQUEUE)) return .AndroidSimpleBufferQueue;
+            if (iidEq(iid, c.SL_IID_ANDROIDBUFFERQUEUESOURCE)) return .AndroidBufferQueueSource;
+            if (iidEq(iid, c.SL_IID_ANDROIDACOUSTICECHOCANCELLATION)) return .AndroidAcousticEchoCancellation;
+            if (iidEq(iid, c.SL_IID_ANDROIDAUTOMATICGAINCONTROL)) return .AndroidAutomaticGainControl;
+            if (iidEq(iid, c.SL_IID_ANDROIDNOISESUPPRESSION)) return .AndroidNoiseSuppresssion;
+            return null;
+        }
+    };
+
+    fn printInterfaces() !void {
+        var interface_count: c.SLuint32 = undefined;
+        try checkResult(c.slQueryNumSupportedEngineInterfaces(&interface_count));
+        {
+            var i: c.SLuint32 = 0;
+            while (i < interface_count) : (i += 1) {
+                var interface_id: c.SLInterfaceID = undefined;
+                try checkResult(c.slQuerySupportedEngineInterfaces(i, &interface_id));
+                const interface_tag = InterfaceID.fromIid(interface_id);
+                if (interface_tag) |tag| {
+                    app_log.info("OpenSL engine interface id: {s}", .{@tagName(tag)});
+                }
+            }
+        }
+    }
+
+    fn printEngineInterfaces() !void {
+        var interface_count: c.SLuint32 = undefined;
+        try checkResult(engine.*.*.QueryNumSupportedInterfaces.?(engine, c.SL_OBJECTID_ENGINE, &interface_count));
+        {
+            var i: c.SLuint32 = 0;
+            while (i < interface_count) : (i += 1) {
+                var interface_id: c.SLInterfaceID = undefined;
+                try checkResult(engine.*.*.QuerySupportedInterfaces.?(engine, c.SL_OBJECTID_ENGINE, i, &interface_id));
+                const interface_tag = InterfaceID.fromIid(interface_id);
+                if (interface_tag) |tag| {
+                    app_log.info("OpenSL engine interface id: {s}", .{@tagName(tag)});
+                } else {
+                    app_log.info("Unknown engine interface id: {}", .{interface_id.*});
+                }
+            }
+        }
+    }
+
+    pub fn init() SLError!void {
+        init_sl_counter += 1;
+        if (init_sl_counter == 1) {
+            try printInterfaces();
+            errdefer init_sl_counter -= 1; // decrement counter on failure
+
+            // Get engine object
+            try checkResult(c.slCreateEngine(&engine_object, 0, null, 0, null, null));
+
+            // Initialize engine object
+            try checkResult(engine_object.*.*.Realize.?(engine_object, c.SL_BOOLEAN_FALSE));
+            errdefer engine_object.*.*.Destroy.?(engine_object);
+
+            // Get engine interface
+            try checkResult(engine_object.*.*.GetInterface.?(engine_object, c.SL_IID_ENGINE, @ptrCast(*anyopaque, &engine)));
+            try printEngineInterfaces();
+        }
+    }
+
+    pub fn deinit() void {
+        std.debug.assert(init_sl_counter > 0);
+
+        if (thread) |t| {
+            t.join();
+            thread = null;
+        }
+
+        // spinlock lock
+        {
+            init_sl_counter -= 1;
+            if (init_sl_counter == 0) {
+                engine_object.*.*.Destroy.?(engine_object);
+            }
+        }
+        // spinlock unlock
+    }
+
+    var thread: ?std.Thread = null;
+
+    pub fn play_test() !void {
+        if (thread == null) {
+            thread = try std.Thread.spawn(.{}, play_thread, .{});
+        }
+    }
+
+    pub fn play_thread() !void {
+        app_log.info("Start play test", .{});
+        const max_interfaces = 3;
+        var required: [max_interfaces]c.SLboolean = .{c.SL_BOOLEAN_FALSE} ** max_interfaces;
+        var iid_array: [max_interfaces]c.SLInterfaceID = .{c.SL_IID_NULL} ** max_interfaces;
+
+        required[0] = c.SL_BOOLEAN_FALSE;
+        iid_array[0] = c.SL_IID_VOLUME;
+
+        // Get OutputMix object
+        try checkResult(engine.*.*.CreateOutputMix.?(engine, &output_mix, 1, &iid_array, &required));
+        app_log.info("Created output mix", .{});
+        try checkResult(output_mix.*.*.Realize.?(output_mix, c.SL_BOOLEAN_FALSE));
+        app_log.info("Realized output mix", .{});
+        defer output_mix.*.*.Destroy.?(output_mix);
+        // Get Volume interface
+        // try checkResult(output_mix.*.*.GetInterface.?(output_mix, c.SL_IID_VOLUME, @ptrCast(*anyopaque, &volume_itf)));
+        // app_log.info("Created volume", .{});
+
+        buffer_queue.locatorType = c.SL_DATALOCATOR_BUFFERQUEUE;
+        buffer_queue.numBuffers = 4;
+
+        // Setup the format of the content in the buffer queue
+        pcm.formatType = c.SL_DATAFORMAT_PCM;
+        pcm.numChannels = 2;
+        pcm.samplesPerSec = c.SL_SAMPLINGRATE_44_1;
+        pcm.bitsPerSample = c.SL_PCMSAMPLEFORMAT_FIXED_16;
+        pcm.containerSize = 16;
+        pcm.channelMask = c.SL_SPEAKER_FRONT_LEFT | c.SL_SPEAKER_FRONT_RIGHT;
+        pcm.endianness = c.SL_BYTEORDER_LITTLEENDIAN;
+
+        audio_source.pFormat = @ptrCast(*anyopaque, &pcm);
+        audio_source.pLocator = @ptrCast(*anyopaque, &buffer_queue);
+
+        // Setup the data sink structure
+        locator_outputmix.locatorType = c.SL_DATALOCATOR_OUTPUTMIX;
+        locator_outputmix.outputMix = output_mix;
+
+        audio_sink.pLocator = @ptrCast(*anyopaque, &locator_outputmix);
+        audio_sink.pFormat = null;
+
+        // Initialize the context for Buffer queue callbacks
+        var context = CallbackContext{
+            .play_itf = undefined,
+            .data_base = pcm_data[0..],
+            .data_index = 0,
+        };
+
+        // Set arrays required and iid_array for SEEK interface (PlayItf is implicit)
+        required[0] = c.SL_BOOLEAN_TRUE;
+        iid_array[0] = c.SL_IID_BUFFERQUEUE;
+
+        // Create the music player
+        try checkResult(engine.*.*.CreateAudioPlayer.?(engine, &player, &audio_source, &audio_sink, 1, &iid_array, &required));
+        app_log.info("Created audio player", .{});
+        try checkResult(player.*.*.Realize.?(player, c.SL_BOOLEAN_FALSE));
+        app_log.info("Realized player", .{});
+        defer player.*.*.Destroy.?(player);
+        try checkResult(player.*.*.GetInterface.?(player, c.SL_IID_PLAY, @ptrCast(*anyopaque, &play_itf)));
+        app_log.info("got play interface", .{});
+        try checkResult(player.*.*.GetInterface.?(player, c.SL_IID_BUFFERQUEUE, @ptrCast(*anyopaque, &buffer_queue_itf)));
+        app_log.info("got buffer queue interface", .{});
+        try checkResult(buffer_queue_itf.*.*.RegisterCallback.?(buffer_queue_itf, bufferQueueCallback, @ptrCast(*anyopaque, &context))); // Register callback
+        app_log.info("registered callback", .{});
+        // try checkResult(volume_itf.*.*.SetVolumeLevel.?(volume_itf, -300)); // Set volume to -3dB (-300mB)
+        // app_log.info("set volume level", .{});
+
+        // Enqueue a few buffers to get the ball rollng
+        try checkResult(buffer_queue_itf.*.*.Enqueue.?(buffer_queue_itf, &context.data_base[context.data_index], 2 * audio_data_buffer_size));
+        context.data_index += audio_data_buffer_size;
+        app_log.info("enqueued buffer", .{});
+        try checkResult(buffer_queue_itf.*.*.Enqueue.?(buffer_queue_itf, &context.data_base[context.data_index], 2 * audio_data_buffer_size));
+        context.data_index += audio_data_buffer_size;
+        app_log.info("enqueued buffer", .{});
+        try checkResult(buffer_queue_itf.*.*.Enqueue.?(buffer_queue_itf, &context.data_base[context.data_index], 2 * audio_data_buffer_size));
+        context.data_index += audio_data_buffer_size;
+        app_log.info("enqueued buffer", .{});
+        try checkResult(buffer_queue_itf.*.*.Enqueue.?(buffer_queue_itf, &context.data_base[context.data_index], 2 * audio_data_buffer_size));
+        context.data_index += audio_data_buffer_size;
+        app_log.info("enqueued buffer", .{});
+
+        try checkResult(play_itf.*.*.SetPlayState.?(play_itf, c.SL_PLAYSTATE_PLAYING));
+        app_log.info("set playstate", .{});
+
+        // Wait until the PCM data is done playing, the buffer queue callback
+        // will continue to queue buffers until the entire PCM data has been
+        // played. This is indicated by waiting for the count member of the
+        // SLBufferQueueState to go to zero.
+        try checkResult(buffer_queue_itf.*.*.GetState.?(buffer_queue_itf, &state));
+        app_log.info("get buffer queue state", .{});
+
+        while (state.count > 0) {
+            try checkResult(buffer_queue_itf.*.*.GetState.?(buffer_queue_itf, &state));
+            // app_log.info("state count {}", .{state.count});
+        }
+        app_log.info("end get buffer queue state loop", .{});
+
+        try checkResult(play_itf.*.*.SetPlayState.?(play_itf, c.SL_PLAYSTATE_STOPPED));
+        app_log.info("set play state stopped", .{});
+    }
+
+    // pub const BufferQueue = struct {
+    //     pub fn callback_playback(buffer_queue: c.SLAndroidSimpleBufferQueueItf, user_data: ?*anyopaque) !void {}
+    //     pub fn callback_capture(buffer_queue: c.SLAndroidSimpleBufferQueueItf, user_data: ?*anyopaque) !void {}
+    // };
+
+    // pub const Device = struct {
+    //     pub fn init(device) !void {}
+
+    //     pub fn deinit(device) void {}
+
+    //     pub fn getInfo(context, device_type, device_id, device_info) !void {}
+
+    //     pub fn enumerate(context, callback, user_data) !void {}
+
+    //     pub fn drain() !void {}
+
+    //     pub fn start(device) !void {
+    //         std.debug.assert(init_sl_counter > 0);
+    //         if (init_sl_counter == 0) return error.OperationInvalid;
+    //         if (device.type == .Capture or device.type == .Duplex) {
+    //             checkResult(audio_recorder.SetRecordState(audio_recorder, c.SL_RECORDSTATE_RECORDING)) catch |e| {
+    //                 // log device here
+    //                 return e;
+    //             };
+
+    //             const period_size_in_bytes = capture.internalPeriodSizeInFrames * getBytesPerFrame();
+    //             var iperiod: usize = 0;
+    //             while (iperiod < device.capture.internal_periods) : (i += 1) {
+    //                 try checkResult(buffer_queue_capture.Enqueue(buffer_queue_capture, buffer_capture + (period_size_in_bytes * iperiod), period_size_in_bytes));
+    //             }
+    //         }
+
+    //         if (device.type == .Playback or device.type == .Duplex) {
+    //             checkResult(audio_player.SetPlayState(audio_player, c.SL_PLAYSTATE_RECORDING)) catch |e| {
+    //                 // log device here
+    //                 return e;
+    //             };
+
+    //             // In playback mode (no duplex) we need to load some initial buffers. In duplex mode we need to enqueue silent buffers.
+    //             if (device.type == .Duplex) {
+    //                 // zero memory
+    //             } else {
+    //                 // read frames from client
+    //             }
+
+    //             const period_size_in_bytes = capture.internalPeriodSizeInFrames * getBytesPerFrame();
+    //             var iperiod: usize = 0;
+    //             while (iperiod < device.capture.internal_periods) : (i += 1) {
+    //                 checkResult(buffer_queue_playback.Enqueue(buffer_queue_playback, buffer_playback + (period_size_in_bytes * iperiod), period_size_in_bytes)) catch |e| {
+    //                     audio_player.SetPlayState(audio_player, c.SL_PLAYSTATE_STOPPED);
+    //                     // log
+    //                     return e;
+    //                 };
+    //             }
+    //         }
+    //     }
+
+    //     pub fn stop(device) void {
+    //         std.debug.assert(init_sl_counter > 0);
+    //     }
+    // };
+
+    const Result = enum(u32) {
+        Success = c.SL_RESULT_SUCCESS,
+        PreconditionsViolated = c.SL_RESULT_PRECONDITIONS_VIOLATED,
+        ParameterInvalid = c.SL_RESULT_PARAMETER_INVALID,
+        MemoryFailure = c.SL_RESULT_MEMORY_FAILURE,
+        ResourceError = c.SL_RESULT_RESOURCE_ERROR,
+        ResourceLost = c.SL_RESULT_RESOURCE_LOST,
+        IoError = c.SL_RESULT_IO_ERROR,
+        BufferInsufficient = c.SL_RESULT_BUFFER_INSUFFICIENT,
+        ContentCorrupted = c.SL_RESULT_CONTENT_CORRUPTED,
+        ContentUnsupported = c.SL_RESULT_CONTENT_UNSUPPORTED,
+        ContentNotFound = c.SL_RESULT_CONTENT_NOT_FOUND,
+        PermissionDenied = c.SL_RESULT_PERMISSION_DENIED,
+        FeatureUnsupported = c.SL_RESULT_FEATURE_UNSUPPORTED,
+        InternalError = c.SL_RESULT_INTERNAL_ERROR,
+        UnknownError = c.SL_RESULT_UNKNOWN_ERROR,
+        OperationAborted = c.SL_RESULT_OPERATION_ABORTED,
+        ControlLost = c.SL_RESULT_CONTROL_LOST,
+        _,
+    };
+
+    const SLError = error{
+        PreconditionsViolated,
+        ParameterInvalid,
+        MemoryFailure,
+        ResourceError,
+        ResourceLost,
+        IoError,
+        BufferInsufficient,
+        ContentCorrupted,
+        ContentUnsupported,
+        ContentNotFound,
+        PermissionDenied,
+        FeatureUnsupported,
+        InternalError,
+        UnknownError,
+        OperationAborted,
+        ControlLost,
+    };
+
+    pub fn checkResult(result: u32) SLError!void {
+        const tag = std.meta.intToEnum(Result, result) catch return error.UnknownError;
+        return switch (tag) {
+            .Success => {},
+            .PreconditionsViolated => error.PreconditionsViolated,
+            .ParameterInvalid => error.ParameterInvalid,
+            .MemoryFailure => error.MemoryFailure,
+            .ResourceError => error.ResourceError,
+            .ResourceLost => error.ResourceLost,
+            .IoError => error.IoError,
+            .BufferInsufficient => error.BufferInsufficient,
+            .ContentCorrupted => error.ContentCorrupted,
+            .ContentUnsupported => error.ContentUnsupported,
+            .ContentNotFound => error.ContentNotFound,
+            .PermissionDenied => error.PermissionDenied,
+            .FeatureUnsupported => error.FeatureUnsupported,
+            .InternalError => error.InternalError,
+            .UnknownError => error.UnknownError,
+            .OperationAborted => error.OperationAborted,
+            .ControlLost => error.ControlLost,
+            else => error.UnknownError,
+        };
+    }
+};

--- a/example/main.zig
+++ b/example/main.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 const android = @import("android");
 
-const audio = @import("audio.zig");
+const audio = android.audio;
 pub const panic = android.panic;
 pub const log = android.log;
 
@@ -372,26 +372,16 @@ pub const AndroidApp = struct {
         // Audio
         self.simple_synth = SimpleSynth.init();
 
-        // audio.OpenSL.init() catch |e| {
-        //     app_log.err("OpenSL init error: {s}", .{@errorName(e)});
-        // };
-        // defer audio.OpenSL.deinit();
+        try audio.init();
 
-        // var output_stream = try audio.OpenSL.getOutputStream(self.allocator, .{
-        //     .sample_format = .Int16,
-        //     .callback = SimpleSynth.audioCallback,
-        //     .user_data = &self.simple_synth,
-        // });
-
-        var output_stream = try audio.AAudio.getOutputStream(self.allocator, .{
+        var output_stream = try audio.getOutputStream(self.allocator, .{
             .sample_format = .Int16,
             .callback = SimpleSynth.audioCallback,
             .user_data = &self.simple_synth,
         });
         defer {
-            output_stream.stop() catch {};
+            output_stream.stop();
             output_stream.deinit();
-            // output_stream.deinit(self.allocator);
         }
 
         try output_stream.start();

--- a/example/main.zig
+++ b/example/main.zig
@@ -49,7 +49,7 @@ pub const AndroidApp = struct {
     screen_width: f32 = undefined,
     screen_height: f32 = undefined,
 
-    audio_engine: audio.AudioEngine = .{},
+    // audio_engine: audio.AudioEngine = .{},
 
     /// This is the entry point which initializes a application
     /// that has stored its previous state.
@@ -221,9 +221,9 @@ pub const AndroidApp = struct {
         std.debug.assert(point.index != null);
         var oldest: *TouchPoint = undefined;
 
-        if (point.index) |index| {
-            self.audio_engine.setToneOn(@intCast(usize, index), true);
-        }
+        // if (point.index) |index| {
+        //     self.audio_engine.setToneOn(@intCast(usize, index), true);
+        // }
 
         for (self.touch_points) |*opt, i| {
             if (opt.*) |*pt| {
@@ -369,11 +369,18 @@ pub const AndroidApp = struct {
         }
 
         // Audio
-        self.audio_engine = audio.AudioEngine{};
-        if (!self.audio_engine.start()) {
-            app_log.info("Couldn't start audio engine", .{});
-        }
-        defer _ = self.audio_engine.stop();
+        // self.audio_engine = audio.AudioEngine{};
+        // if (!self.audio_engine.start()) {
+        //     app_log.info("Couldn't start audio engine", .{});
+        // }
+        // defer _ = self.audio_engine.stop();
+        audio.OpenSL.init() catch |e| {
+            app_log.err("OpenSL init error: {s}", .{@errorName(e)});
+        };
+        audio.OpenSL.play_test() catch |e| {
+            app_log.err("OpenSL play_test error: {s}", .{@errorName(e)});
+        };
+        defer audio.OpenSL.deinit();
 
         // Graphics
         const GLuint = c.GLuint;
@@ -629,9 +636,9 @@ pub const AndroidApp = struct {
 
                             point.intensity -= 0.05;
                             if (point.intensity <= 0.0) {
-                                if (point.index) |index| {
-                                    self.audio_engine.setToneOn(@intCast(usize, index), false);
-                                }
+                                // if (point.index) |index| {
+                                //     self.audio_engine.setToneOn(@intCast(usize, index), false);
+                                // }
                                 pt.* = null;
                             }
                         }

--- a/example/main.zig
+++ b/example/main.zig
@@ -370,27 +370,28 @@ pub const AndroidApp = struct {
         }
 
         // Audio
-        // self.audio_engine = audio.AudioEngine{};
-        // if (!self.audio_engine.start()) {
-        //     app_log.info("Couldn't start audio engine", .{});
-        // }
-        // defer _ = self.audio_engine.stop();
-
-        audio.OpenSL.init() catch |e| {
-            app_log.err("OpenSL init error: {s}", .{@errorName(e)});
-        };
-        defer audio.OpenSL.deinit();
-
         self.simple_synth = SimpleSynth.init();
 
-        var output_stream = try audio.OpenSL.getOutputStream(self.allocator, .{
+        // audio.OpenSL.init() catch |e| {
+        //     app_log.err("OpenSL init error: {s}", .{@errorName(e)});
+        // };
+        // defer audio.OpenSL.deinit();
+
+        // var output_stream = try audio.OpenSL.getOutputStream(self.allocator, .{
+        //     .sample_format = .Int16,
+        //     .callback = SimpleSynth.audioCallback,
+        //     .user_data = &self.simple_synth,
+        // });
+
+        var output_stream = try audio.AAudio.getOutputStream(self.allocator, .{
             .sample_format = .Int16,
             .callback = SimpleSynth.audioCallback,
             .user_data = &self.simple_synth,
         });
         defer {
             output_stream.stop() catch {};
-            output_stream.deinit(self.allocator);
+            output_stream.deinit();
+            // output_stream.deinit(self.allocator);
         }
 
         try output_stream.start();

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
           zig = zig.packages.${system}.master;
           android-sdk = android.sdk.${system} (sdkPkgs: with sdkPkgs; [
             # Useful packages for building and testing.
-            build-tools-30-0-2
+            build-tools-33-0-0
             cmdline-tools-latest
             emulator
             platform-tools

--- a/src/aaudio.zig
+++ b/src/aaudio.zig
@@ -1,0 +1,175 @@
+const std = @import("std");
+
+const c = @import("c.zig");
+
+const OutputStreamConfig = @import("audio.zig").OutputStreamConfig;
+const StreamLayout = @import("audio.zig").StreamLayout;
+
+const audio_log = std.log.scoped(.audio);
+
+pub const AAudio = struct {
+    pub const OutputStream = struct {
+        config: OutputStreamConfig,
+        stream: ?*c.AAudioStream,
+
+        pub fn start(output_stream: *@This()) !void {
+            try checkResult(c.AAudioStream_requestStart(output_stream.stream));
+        }
+
+        pub fn stop(output_stream: *@This()) void {
+            checkResult(c.AAudioStream_requestStop(output_stream.stream)) catch |e| {
+                audio_log.err("Error stopping stream {s}", .{@errorName(e)});
+            };
+        }
+
+        pub fn deinit(output_stream: *@This()) void {
+            checkResult(c.AAudioStream_close(output_stream.stream)) catch |e| {
+                audio_log.err("Error deiniting stream {s}", .{@errorName(e)});
+            };
+        }
+    };
+
+    fn dataCallback(
+        stream: ?*c.AAudioStream,
+        user_data: ?*anyopaque,
+        audio_data: ?*anyopaque,
+        num_frames: i32,
+    ) callconv(.C) c.aaudio_data_callback_result_t {
+        _ = stream;
+        const output_stream = @ptrCast(*OutputStream, @alignCast(@alignOf(OutputStream), user_data.?));
+        // TODO:
+        // const audio_slice = @ptrCast([*]f32, @alignCast(@alignOf(f32), audio_data.?))[0..@intCast(usize, num_frames)];
+        const audio_slice = @ptrCast([*]i16, @alignCast(@alignOf(i16), audio_data.?))[0..@intCast(usize, num_frames)];
+
+        for (audio_slice) |*frame| {
+            frame.* = 0;
+        }
+
+        var stream_layout = StreamLayout{
+            .sample_rate = output_stream.config.sample_rate.?,
+            .channel_count = @intCast(usize, output_stream.config.channel_count),
+            .buffer = .{ .Int16 = audio_slice },
+        };
+
+        output_stream.config.callback(stream_layout, output_stream.config.user_data);
+
+        return c.AAUDIO_CALLBACK_RESULT_CONTINUE;
+    }
+
+    fn errorCallback(
+        stream: ?*c.AAudioStream,
+        user_data: ?*anyopaque,
+        err: c.aaudio_result_t,
+    ) callconv(.C) void {
+        _ = stream;
+        audio_log.err("AAudio Stream error! {}", .{err});
+        if (err == c.AAUDIO_ERROR_DISCONNECTED) {
+            const output_stream = @ptrCast(*OutputStream, @alignCast(@alignOf(OutputStream), user_data.?));
+            _ = std.Thread.spawn(.{}, OutputStream.deinit, .{output_stream}) catch @panic("Error starting thread for AAudioOutputStream");
+        }
+    }
+
+    pub fn getOutputStream(allocator: std.mem.Allocator, config: OutputStreamConfig) !*OutputStream {
+        errdefer audio_log.err("Encountered an error with getting output stream", .{});
+        // Create a stream builder
+        var stream_builder: ?*c.AAudioStreamBuilder = null;
+        checkResult(c.AAudio_createStreamBuilder(&stream_builder)) catch |e| {
+            audio_log.err("Couldn't create audio stream builder: {s}", .{@errorName(e)});
+            return e;
+        };
+        defer checkResult(c.AAudioStreamBuilder_delete(stream_builder)) catch |e| {
+            // TODO
+            audio_log.err("Issue with deleting stream builder: {s}", .{@errorName(e)});
+        };
+
+        var output_stream = try allocator.create(OutputStream);
+        output_stream.* = OutputStream{
+            .config = config,
+            .stream = undefined,
+        };
+
+        // Configure the stream
+        c.AAudioStreamBuilder_setFormat(stream_builder, switch (config.sample_format) {
+            .Uint8 => return error.Unsupported,
+            .Int16 => c.AAUDIO_FORMAT_PCM_I16,
+            .Float32 => c.AAUDIO_FORMAT_PCM_FLOAT,
+        });
+        c.AAudioStreamBuilder_setChannelCount(stream_builder, @intCast(i32, config.channel_count));
+        c.AAudioStreamBuilder_setPerformanceMode(stream_builder, c.AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
+        c.AAudioStreamBuilder_setDataCallback(stream_builder, dataCallback, output_stream);
+        c.AAudioStreamBuilder_setErrorCallback(stream_builder, errorCallback, output_stream);
+
+        if (config.sample_rate) |rate| c.AAudioStreamBuilder_setSampleRate(stream_builder, @intCast(i32, rate));
+        if (config.buffer_size) |size| c.AAudioStreamBuilder_setFramesPerDataCallback(stream_builder, @intCast(i32, size));
+
+        // Open the stream
+        checkResult(c.AAudioStreamBuilder_openStream(stream_builder, &output_stream.stream)) catch |e| {
+            audio_log.err("Issue with opening stream: {s}", .{@errorName(e)});
+            return e;
+        };
+
+        // Save the details of the stream
+        output_stream.config.sample_rate = @intCast(u32, c.AAudioStream_getSampleRate(output_stream.stream));
+        output_stream.config.buffer_size = @intCast(usize, c.AAudioStream_getFramesPerBurst(output_stream.stream));
+
+        var res = c.AAudioStream_setBufferSizeInFrames(output_stream.stream, @intCast(i32, output_stream.config.buffer_count * output_stream.config.buffer_size.?));
+        if (res < 0) {
+            checkResult(res) catch |e| {
+                audio_log.err("Issue with setting buffer size in frames stream: {s}", .{@errorName(e)});
+                return e;
+            };
+        } else {
+            // TODO: store buffer size somewhere
+            // output_stream.config.
+        }
+
+        audio_log.info("Got AAudio OutputStream", .{});
+
+        return output_stream;
+    }
+
+    pub const AAudioError = error{
+        Base,
+        Disconnected,
+        IllegalArgument,
+        Internal,
+        InvalidState,
+        InvalidHandle,
+        Unimplemented,
+        Unavailable,
+        NoFreeHandles,
+        NoMemory,
+        Null,
+        Timeout,
+        WouldBlock,
+        InvalidFormat,
+        OutOfRange,
+        NoService,
+        InvalidRate,
+        Unknown,
+    };
+
+    pub fn checkResult(result: c.aaudio_result_t) AAudioError!void {
+        return switch (result) {
+            c.AAUDIO_OK => {},
+            c.AAUDIO_ERROR_BASE => error.Base,
+            c.AAUDIO_ERROR_DISCONNECTED => error.Disconnected,
+            c.AAUDIO_ERROR_ILLEGAL_ARGUMENT => error.IllegalArgument,
+            c.AAUDIO_ERROR_INTERNAL => error.Internal,
+            c.AAUDIO_ERROR_INVALID_STATE => error.InvalidState,
+            c.AAUDIO_ERROR_INVALID_HANDLE => error.InvalidHandle,
+            c.AAUDIO_ERROR_UNIMPLEMENTED => error.Unimplemented,
+            c.AAUDIO_ERROR_UNAVAILABLE => error.Unavailable,
+            c.AAUDIO_ERROR_NO_FREE_HANDLES => error.NoFreeHandles,
+            c.AAUDIO_ERROR_NO_MEMORY => error.NoMemory,
+            c.AAUDIO_ERROR_NULL => error.Null,
+            c.AAUDIO_ERROR_TIMEOUT => error.Timeout,
+            c.AAUDIO_ERROR_WOULD_BLOCK => error.WouldBlock,
+            c.AAUDIO_ERROR_INVALID_FORMAT => error.InvalidFormat,
+            c.AAUDIO_ERROR_OUT_OF_RANGE => error.OutOfRange,
+            c.AAUDIO_ERROR_NO_SERVICE => error.NoService,
+            c.AAUDIO_ERROR_INVALID_RATE => error.InvalidRate,
+            else => error.Unknown,
+        };
+    }
+};

--- a/src/android-support.zig
+++ b/src/android-support.zig
@@ -8,6 +8,7 @@ const build_options = @import("build_options");
 
 pub const egl = @import("egl.zig");
 pub const JNI = @import("jni.zig").JNI;
+// pub const audio = @import("audio.zig");
 
 const app_log = std.log.scoped(.app_glue);
 

--- a/src/android-support.zig
+++ b/src/android-support.zig
@@ -8,7 +8,7 @@ const build_options = @import("build_options");
 
 pub const egl = @import("egl.zig");
 pub const JNI = @import("jni.zig").JNI;
-// pub const audio = @import("audio.zig");
+pub const audio = @import("audio.zig");
 
 const app_log = std.log.scoped(.app_glue);
 

--- a/src/audio.zig
+++ b/src/audio.zig
@@ -1,0 +1,94 @@
+const std = @import("std");
+const build_options = @import("build_options");
+
+const android = @import("c.zig");
+
+const audio_log = std.log.scoped(.audio);
+
+const Dummy = @import("dummy.zig").Dummy;
+
+const OpenSL = if (build_options.enable_opensl) @import("opensl.zig").OpenSL else Dummy;
+const AAudio = if (build_options.enable_aaudio) @import("aaudio.zig").AAudio else Dummy;
+
+pub fn midiToFreq(note: usize) f64 {
+    return std.math.pow(f64, 2, (@intToFloat(f64, note) - 49) / 12) * 440;
+}
+
+pub fn amplitudeTodB(amplitude: f64) f64 {
+    return 20.0 * std.math.log10(amplitude);
+}
+
+pub fn dBToAmplitude(dB: f64) f64 {
+    return std.math.pow(f64, 10.0, dB / 20.0);
+}
+
+pub const StreamLayout = struct {
+    sample_rate: u32,
+    channel_count: usize,
+    buffer: union(enum) {
+        Uint8: []u8,
+        Int16: []i16,
+        Float32: []f32,
+    },
+};
+
+const StreamCallbackFn = *const fn (StreamLayout, *anyopaque) void;
+
+pub const AudioManager = struct {};
+
+pub const OutputStreamConfig = struct {
+    // Leave null to use the the platforms native sampling rate
+    sample_rate: ?u32 = null,
+    sample_format: enum {
+        Uint8,
+        Int16,
+        Float32,
+    },
+    buffer_size: ?usize = null,
+    buffer_count: usize = 4,
+    channel_count: usize = 1,
+    callback: StreamCallbackFn,
+    user_data: *anyopaque,
+};
+
+pub fn init() !void {
+    if (build_options.enable_opensl) {
+        try OpenSL.init();
+    }
+}
+
+pub fn getOutputStream(allocator: std.mem.Allocator, config: OutputStreamConfig) !OutputStream {
+    if (build_options.enable_aaudio) {
+        return .{ .AAudio = try AAudio.getOutputStream(allocator, config) };
+    }
+    if (build_options.enable_opensl) {
+        return .{ .OpenSL = try OpenSL.getOutputStream(allocator, config) };
+    }
+    return error.NoBackendsAvailable;
+}
+
+pub const OutputStream = union(enum) {
+    OpenSL: *OpenSL.OutputStream,
+    AAudio: *AAudio.OutputStream,
+
+    pub fn stop(output_stream: @This()) void {
+        switch (output_stream) {
+            .OpenSL => |opensl| opensl.stop(),
+            .AAudio => |aaudio| aaudio.stop(),
+        }
+    }
+
+    pub fn deinit(output_stream: @This()) void {
+        switch (output_stream) {
+            .OpenSL => |opensl| opensl.deinit(),
+            .AAudio => |aaudio| aaudio.deinit(),
+        }
+    }
+
+    pub fn start(output_stream: @This()) !void {
+        switch (output_stream) {
+            .OpenSL => |opensl| try opensl.start(),
+            .AAudio => |aaudio| try aaudio.start(),
+        }
+    }
+};

--- a/src/c.zig
+++ b/src/c.zig
@@ -1,11 +1,16 @@
+const build_options = @import("build_options");
 pub usingnamespace @cImport({
     @cInclude("EGL/egl.h");
     // @cInclude("EGL/eglext.h");
     @cInclude("GLES2/gl2.h");
     @cInclude("GLES2/gl2ext.h");
-    @cInclude("aaudio/AAudio.h");
-    @cInclude("SLES/OpenSLES.h");
-    @cInclude("SLES/OpenSLES_Android.h");
     // @cInclude("unwind.h");
     // @cInclude("dlfcn.h");
+    if (build_options.enable_aaudio) {
+        @cInclude("aaudio/AAudio.h");
+    }
+    if (build_options.enable_opensl) {
+        @cInclude("SLES/OpenSLES.h");
+        @cInclude("SLES/OpenSLES_Android.h");
+    }
 });

--- a/src/c.zig
+++ b/src/c.zig
@@ -4,6 +4,8 @@ pub usingnamespace @cImport({
     @cInclude("GLES2/gl2.h");
     @cInclude("GLES2/gl2ext.h");
     @cInclude("aaudio/AAudio.h");
+    @cInclude("SLES/OpenSLES.h");
+    @cInclude("SLES/OpenSLES_Android.h");
     // @cInclude("unwind.h");
     // @cInclude("dlfcn.h");
 });

--- a/src/c.zig
+++ b/src/c.zig
@@ -3,6 +3,7 @@ pub usingnamespace @cImport({
     // @cInclude("EGL/eglext.h");
     @cInclude("GLES2/gl2.h");
     @cInclude("GLES2/gl2ext.h");
+    @cInclude("aaudio/AAudio.h");
     // @cInclude("unwind.h");
     // @cInclude("dlfcn.h");
 });

--- a/src/dummy.zig
+++ b/src/dummy.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+
+const OutputStreamConfig = @import("audio.zig").OutputStreamConfig;
+const StreamLayout = @import("audio.zig").StreamLayout;
+
+pub const Dummy = struct {
+    pub fn getOutputStream(allocator: std.mem.Allocator, config: OutputStreamConfig ) !OutputStream {
+        _ = allocator;
+        _ = config;
+        return error.Unimplemented;
+    }
+
+    pub const OutputStream = struct {
+        pub fn stop(_: *@This()) void {}
+        pub fn deinit(_: *@This()) void {}
+        pub fn start(_: *@This()) !void{}
+    };
+};


### PR DESCRIPTION
This branch implements incomplete support for Audio with ZigAndroidTemplate using either AAudio (api level 30 or higher) or OpenSL (api level 16 or higher). The example app will play back a chord of sine waves for each finger that is being tracked.

- Sample  data only supports `i16` right now
- The build sytem will not warn you if you try to use an unsupported audio backend on an older version of android
- I put the `app_libs` build variable into the configuration - libraries should probably be added/removed by the Sdk

I'm sure there are other problems with it, let me know if you find any.