### PR TITLE
Explicit intent

### DIFF
--- a/Sdk.zig
+++ b/Sdk.zig
@@ -450,7 +450,7 @@ pub fn createApp(
         if (app_config.fullscreen) {
             writer.writeAll(
                 \\    <application android:debuggable="true" android:hasCode="false" android:label="@string/app_name" android:theme="@android:style/Theme.NoTitleBar.Fullscreen" tools:replace="android:icon,android:theme,android:allowBackup,label" android:icon="@mipmap/icon" >
-                \\        <activity android:configChanges="keyboardHidden|orientation" android:name="android.app.NativeActivity">
+                \\        <activity android:exported="true" android:configChanges="keyboardHidden|orientation" android:name="android.app.NativeActivity">
                 \\            <meta-data android:name="android.app.lib_name" android:value="@string/lib_name"/>
                 \\            <intent-filter>
                 \\                <action android:name="android.intent.action.MAIN"/>
@@ -464,7 +464,7 @@ pub fn createApp(
         } else {
             writer.writeAll(
                 \\    <application android:debuggable="true" android:hasCode="false" android:label="@string/app_name" tools:replace="android:icon,android:theme,android:allowBackup,label" android:icon="@mipmap/icon">
-                \\        <activity android:configChanges="keyboardHidden|orientation" android:name="android.app.NativeActivity">
+                \\        <activity android:exported="true" android:configChanges="keyboardHidden|orientation" android:name="android.app.NativeActivity">
                 \\            <meta-data android:name="android.app.lib_name" android:value="@string/lib_name"/>
                 \\            <intent-filter>
                 \\                <action android:name="android.intent.action.MAIN"/>

--- a/Sdk.zig
+++ b/Sdk.zig
@@ -813,7 +813,7 @@ pub fn compileAppLibrary(
     exe.install();
 
     // TODO: Remove when https://github.com/ziglang/zig/issues/7935 is resolved:
-    if (exe.target.getCpuArch() == .@"i386") {
+    if (exe.target.getCpuArch() == .x86) {
         exe.link_z_notext = true;
     }
 
@@ -986,7 +986,7 @@ const zig_targets = struct {
     };
 
     const x86 = std.zig.CrossTarget{
-        .cpu_arch = .i386,
+        .cpu_arch = .x86,
         .os_tag = android_os,
         .abi = android_abi,
         .cpu_model = .baseline,


### PR DESCRIPTION
On android 31+ (Android 12) you need to explicitly use android:exported 