### PR TITLE
Invocation handler

### DIFF
--- a/Sdk.zig
+++ b/Sdk.zig
@@ -462,7 +462,7 @@ pub fn createApp(
 
         if (app_config.fullscreen) {
             writer.writeAll(
-                \\    <application android:debuggable="true" android:hasCode="false" android:label="@string/app_name" android:theme="@android:style/Theme.NoTitleBar.Fullscreen" tools:replace="android:icon,android:theme,android:allowBackup,label" android:icon="@mipmap/icon" >
+                \\    <application android:debuggable="true" android:hasCode="true" android:label="@string/app_name" android:theme="@android:style/Theme.NoTitleBar.Fullscreen" tools:replace="android:icon,android:theme,android:allowBackup,label" android:icon="@mipmap/icon" >
                 \\        <activity android:configChanges="keyboardHidden|orientation" android:name="android.app.NativeActivity">
                 \\            <meta-data android:name="android.app.lib_name" android:value="@string/lib_name"/>
                 \\            <intent-filter>
@@ -476,7 +476,7 @@ pub fn createApp(
             ) catch unreachable;
         } else {
             writer.writeAll(
-                \\    <application android:debuggable="true" android:hasCode="false" android:label="@string/app_name" tools:replace="android:icon,android:theme,android:allowBackup,label" android:icon="@mipmap/icon">
+                \\    <application android:debuggable="true" android:hasCode="true" android:label="@string/app_name" tools:replace="android:icon,android:theme,android:allowBackup,label" android:icon="@mipmap/icon">
                 \\        <activity android:configChanges="keyboardHidden|orientation" android:name="android.app.NativeActivity">
                 \\            <meta-data android:name="android.app.lib_name" android:value="@string/lib_name"/>
                 \\            <intent-filter>

--- a/build.zig
+++ b/build.zig
@@ -68,11 +68,12 @@ pub fn build(b: *std.build.Builder) !void {
 
     // Replace by your app's main file.
     // Here this is some code to choose the example to run
-    const ExampleType = enum { egl, textview };
+    const ExampleType = enum { egl, textview, invocationhandler };
     const example = b.option(ExampleType, "example", "Which example to run") orelse .egl;
     const src = switch (example) {
         .egl => "examples/egl/main.zig",
         .textview => "examples/textview/main.zig",
+        .invocationhandler => "examples/invocationhandler/main.zig",
     };
 
     const app = sdk.createApp(

--- a/build.zig
+++ b/build.zig
@@ -75,10 +75,15 @@ pub fn build(b: *std.build.Builder) !void {
         .textview => "examples/textview/main.zig",
         .invocationhandler => "examples/invocationhandler/main.zig",
     };
+    const dex: ?[:0]const u8 = switch (example) {
+        .invocationhandler => "classes.dex",
+        else => null,
+    };
 
     const app = sdk.createApp(
         "app-template.apk",
         src,
+        dex,
         config,
         mode,
         .{

--- a/build.zig
+++ b/build.zig
@@ -75,8 +75,8 @@ pub fn build(b: *std.build.Builder) !void {
         .textview => "examples/textview/main.zig",
         .invocationhandler => "examples/invocationhandler/main.zig",
     };
-    const dex: ?[:0]const u8 = switch (example) {
-        .invocationhandler => "classes.dex",
+    const dex: ?[]const [:0]const u8 = switch (example) {
+        .invocationhandler => &[_][:0]const u8{"src/NativeInvocationHandler.java"},
         else => null,
     };
 

--- a/examples/egl/main.zig
+++ b/examples/egl/main.zig
@@ -8,6 +8,7 @@ pub const log = android.log;
 
 const EGLContext = android.egl.EGLContext;
 const JNI = android.JNI;
+const NativeActivity = android.NativeActivity;
 const c = android.egl.c;
 
 const app_log = std.log.scoped(.app);
@@ -200,10 +201,10 @@ pub const AndroidApp = struct {
         });
 
         if (event_type == .AKEY_EVENT_ACTION_DOWN) {
-            var jni = JNI.init(self.activity);
-            defer jni.deinit();
+            var native_activity = NativeActivity.init(self.activity);
+            defer native_activity.deinit();
 
-            var codepoint = jni.AndroidGetUnicodeChar(
+            var codepoint = try native_activity.AndroidGetUnicodeChar(
                 android.AKeyEvent_getKeyCode(event),
                 android.AKeyEvent_getMetaState(event),
             );
@@ -252,21 +253,21 @@ pub const AndroidApp = struct {
         const event_type = @intToEnum(android.AMotionEventActionType, android.AMotionEvent_getAction(event));
 
         {
-            var jni = JNI.init(self.activity);
-            defer jni.deinit();
+            var native_activity = NativeActivity.init(self.activity);
+            defer native_activity.deinit();
 
             // Show/Hide keyboard
-            // _ = jni.AndroidDisplayKeyboard(true);
+            // _ = native_activity.AndroidDisplayKeyboard(true);
 
             // this allows you to send the app in the background
-            // const success = jni.AndroidSendToBack(true);
+            // const success = native_activity.AndroidSendToBack(true);
             // _ = success;
             // std.log.scoped(.input).debug("SendToBack() = {}\n", .{success});
 
             // This is a demo on how to request permissions:
             if (event_type == .AMOTION_EVENT_ACTION_UP) {
-                if (!JNI.AndroidHasPermissions(&jni, "android.permission.RECORD_AUDIO")) {
-                    JNI.AndroidRequestAppPermissions(&jni, "android.permission.RECORD_AUDIO");
+                if (!try NativeActivity.AndroidHasPermissions(&native_activity, "android.permission.RECORD_AUDIO")) {
+                    try NativeActivity.AndroidRequestAppPermissions(&native_activity, "android.permission.RECORD_AUDIO");
                 }
             }
         }
@@ -350,11 +351,11 @@ pub const AndroidApp = struct {
 
     fn mainLoop(self: *Self) !void {
         // This code somehow crashes yet. Needs more investigations
-        var jni = JNI.init(self.activity);
-        defer jni.deinit();
+        var native_activity = NativeActivity.init(self.activity);
+        defer native_activity.deinit();
 
         // Must be called from main thread…
-        _ = jni.AndroidMakeFullscreen();
+        _ = try native_activity.AndroidMakeFullscreen();
 
         var loop: usize = 0;
         app_log.info("mainLoop() started\n", .{});

--- a/examples/egl/main.zig
+++ b/examples/egl/main.zig
@@ -4,7 +4,6 @@ const android = @import("android");
 
 const audio = android.audio;
 pub const panic = android.panic;
-pub const log = android.log;
 
 const EGLContext = android.egl.EGLContext;
 const JNI = android.JNI;

--- a/examples/invocationhandler/main.zig
+++ b/examples/invocationhandler/main.zig
@@ -3,7 +3,6 @@ const std = @import("std");
 const android = @import("android");
 
 pub const panic = android.panic;
-pub const log = android.log;
 
 const EGLContext = android.egl.EGLContext;
 const JNI = android.JNI;
@@ -14,7 +13,6 @@ const NativeInvocationHandler = android.NativeInvocationHandler;
 const app_log = std.log.scoped(.app);
 comptime {
     _ = android.ANativeActivity_createFunc;
-    _ = @import("root").log;
 }
 
 const ButtonData = struct {

--- a/examples/invocationhandler/main.zig
+++ b/examples/invocationhandler/main.zig
@@ -16,11 +16,12 @@ comptime {
     _ = @import("root").log;
 }
 
-pub fn timerInvoke(_: ?*anyopaque, jni: JNI, method: android.jobject, args: android.jobjectArray) void {
+pub fn timerInvoke(_: ?*anyopaque, jni: *android.JNIEnv, method: android.jobject, args: android.jobjectArray) android.jobject {
     _ = jni;
     _ = method;
     _ = args;
-    std.log.info("Running timer!", .{});
+    std.log.info("Running invoke!", .{});
+    return null;
 }
 
 pub const AndroidApp = struct {

--- a/examples/invocationhandler/main.zig
+++ b/examples/invocationhandler/main.zig
@@ -20,7 +20,7 @@ const ButtonData = struct {
     count: usize = 0,
 };
 
-pub fn timerInvoke(data: ?*anyopaque, jni: android.jni.JNI, method: android.jobject, args: android.jobjectArray) android.jobject {
+pub fn timerInvoke(data: ?*anyopaque, jni: *android.jni.JNI, method: android.jobject, args: android.jobjectArray) android.jobject {
     var btn_data = @ptrCast(*ButtonData, @alignCast(@alignOf(*ButtonData), data));
     btn_data.count += 1;
     std.log.info("Running invoke!", .{});
@@ -220,7 +220,7 @@ pub const AndroidApp = struct {
         }
     }
 
-    fn getOnClickListener(self: *AndroidApp, jni: JNI) !android.jobject {
+    fn getOnClickListener(self: *AndroidApp, jni: *JNI) !android.jobject {
         // Get class loader
         // const activityClass = self.activity.clazz;
         const activityClass = jni.findClass("android/app/NativeActivity");

--- a/examples/invocationhandler/main.zig
+++ b/examples/invocationhandler/main.zig
@@ -1,0 +1,261 @@
+const std = @import("std");
+
+const android = @import("android");
+
+pub const panic = android.panic;
+pub const log = android.log;
+
+const EGLContext = android.egl.EGLContext;
+const JNI = android.JNI;
+const c = android.egl.c;
+const NativeInvocationHandler = android.NativeInvocationHandler;
+
+const app_log = std.log.scoped(.app);
+comptime {
+    _ = android.ANativeActivity_createFunc;
+    _ = @import("root").log;
+}
+
+pub fn timerInvoke(_: ?*anyopaque, jni: JNI, method: android.jobject, args: android.jobjectArray) void {
+    _ = jni;
+    _ = method;
+    _ = args;
+    std.log.info("Running timer!", .{});
+}
+
+pub const AndroidApp = struct {
+    allocator: std.mem.Allocator,
+    activity: *android.ANativeActivity,
+    thread: ?std.Thread = null,
+    running: bool = true,
+
+    // The JNIEnv of the UI thread
+    uiJni: JNI = undefined,
+    // The JNIEnv of the app thread
+    mainJni: JNI = undefined,
+
+    invocation_handler: NativeInvocationHandler = undefined,
+
+    // This is needed because to run a callback on the UI thread Looper you must
+    // react to a fd change, so we use a pipe to force it
+    pipe: [2]std.os.fd_t = undefined,
+    // This is used with futexes so that runOnUiThread waits until the callback is completed
+    // before returning.
+    uiThreadCondition: std.atomic.Atomic(u32) = std.atomic.Atomic(u32).init(0),
+    uiThreadLooper: *android.ALooper = undefined,
+    uiThreadId: std.Thread.Id = undefined,
+
+    pub fn init(allocator: std.mem.Allocator, activity: *android.ANativeActivity, stored_state: ?[]const u8) !AndroidApp {
+        _ = stored_state;
+
+        return AndroidApp{
+            .allocator = allocator,
+            .activity = activity,
+        };
+    }
+
+    pub fn start(self: *AndroidApp) !void {
+        // Initialize the variables we need to execute functions on the UI thread
+        self.uiThreadLooper = android.ALooper_forThread().?;
+        self.uiThreadId = std.Thread.getCurrentId();
+        self.pipe = try std.os.pipe();
+        android.ALooper_acquire(self.uiThreadLooper);
+
+        var jni = JNI.init(self.activity);
+        self.uiJni = jni;
+
+        // Get the window object attached to our activity
+        const activityClass = jni.findClass("android/app/NativeActivity");
+        const getWindow = jni.invokeJni(.GetMethodID, .{ activityClass, "getWindow", "()Landroid/view/Window;" });
+        const activityWindow = jni.invokeJni(.CallObjectMethod, .{ self.activity.clazz, getWindow });
+        const WindowClass = jni.findClass("android/view/Window");
+
+        try self.runTimer(jni);
+
+        // This disables the surface handler set by default by android.view.NativeActivity
+        // This way we let the content view do the drawing instead of us.
+        const takeSurface = jni.invokeJni(.GetMethodID, .{ WindowClass, "takeSurface", "(Landroid/view/SurfaceHolder$Callback2;)V" });
+        jni.invokeJni(.CallVoidMethod, .{
+            activityWindow,
+            takeSurface,
+            @as(android.jobject, null),
+        });
+
+        // Do the same but with the input queue. This allows the content view to handle input.
+        const takeInputQueue = jni.invokeJni(.GetMethodID, .{ WindowClass, "takeInputQueue", "(Landroid/view/InputQueue$Callback;)V" });
+        jni.invokeJni(.CallVoidMethod, .{
+            activityWindow,
+            takeInputQueue,
+            @as(android.jobject, null),
+        });
+        self.thread = try std.Thread.spawn(.{}, mainLoop, .{self});
+    }
+
+    /// Run the given function on the Android UI thread. This is necessary for manipulating the view hierarchy.
+    /// Note: this function is not thread-safe, but could be made so simply using a mutex
+    pub fn runOnUiThread(self: *AndroidApp, comptime func: anytype, args: anytype) !void {
+        if (std.Thread.getCurrentId() == self.uiThreadId) {
+            // runOnUiThread has been called from the UI thread.
+            @call(.auto, func, args);
+            return;
+        }
+
+        const Args = @TypeOf(args);
+        const allocator = self.allocator;
+
+        const Data = struct { args: Args, self: *AndroidApp };
+
+        const data_ptr = try allocator.create(Data);
+        data_ptr.* = .{ .args = args, .self = self };
+        errdefer allocator.destroy(data_ptr);
+
+        const Instance = struct {
+            fn callback(_: c_int, _: c_int, data: ?*anyopaque) callconv(.C) c_int {
+                const data_struct = @ptrCast(*Data, @alignCast(@alignOf(Data), data.?));
+                const self_ptr = data_struct.self;
+                defer self_ptr.allocator.destroy(data_struct);
+
+                @call(.auto, func, data_struct.args);
+                std.Thread.Futex.wake(&self_ptr.uiThreadCondition, 1);
+                return 0;
+            }
+        };
+
+        const result = android.ALooper_addFd(
+            self.uiThreadLooper,
+            self.pipe[0],
+            0,
+            android.ALOOPER_EVENT_INPUT,
+            Instance.callback,
+            data_ptr,
+        );
+        std.debug.assert(try std.os.write(self.pipe[1], "hello") == 5);
+        if (result == -1) {
+            return error.LooperError;
+        }
+
+        std.Thread.Futex.wait(&self.uiThreadCondition, 0);
+    }
+
+    pub fn getJni(self: *AndroidApp) JNI {
+        return JNI.get(self.activity);
+    }
+
+    pub fn deinit(self: *AndroidApp) void {
+        @atomicStore(bool, &self.running, false, .SeqCst);
+        if (self.thread) |thread| {
+            thread.join();
+            self.thread = null;
+        }
+        android.ALooper_release(self.uiThreadLooper);
+        self.uiJni.deinit();
+    }
+
+    fn setAppContentView(self: *AndroidApp) void {
+        const jni = self.getJni();
+
+        // We create a new TextView..
+        std.log.warn("Creating android.widget.TextView", .{});
+        const TextView = jni.findClass("android/widget/TextView");
+        const textViewInit = jni.invokeJni(.GetMethodID, .{ TextView, "<init>", "(Landroid/content/Context;)V" });
+        const textView = jni.invokeJni(.NewObject, .{ TextView, textViewInit, self.activity.clazz });
+
+        // .. and set its text to "Hello from Zig!"
+        const setText = jni.invokeJni(.GetMethodID, .{ TextView, "setText", "(Ljava/lang/CharSequence;)V" });
+        jni.invokeJni(.CallVoidMethod, .{ textView, setText, jni.newString("Hello from Zig!") });
+
+        // And then we use it as our content view!
+        std.log.err("Attempt to call NativeActivity.setContentView()", .{});
+        const activityClass = jni.findClass("android/app/NativeActivity");
+        const setContentView = jni.invokeJni(.GetMethodID, .{ activityClass, "setContentView", "(Landroid/view/View;)V" });
+        jni.invokeJni(.CallVoidMethod, .{
+            self.activity.clazz,
+            setContentView,
+            textView,
+        });
+    }
+
+    fn mainLoop(self: *AndroidApp) !void {
+        self.mainJni = JNI.init(self.activity);
+        defer self.mainJni.deinit();
+
+        try self.runOnUiThread(setAppContentView, .{self});
+        while (self.running) {
+            std.time.sleep(1 * std.time.ns_per_s);
+        }
+    }
+
+    fn runTimer(self: *AndroidApp, jni: JNI) !void {
+        // Get class loader
+        // const activityClass = self.activity.clazz;
+        const activityClass = jni.findClass("android/app/NativeActivity");
+        std.log.info("activityclass {any}", .{activityClass});
+        const getClassLoader = jni.invokeJni(.GetMethodID, .{ activityClass, "getClassLoader", "()Ljava/lang/ClassLoader;" });
+        std.log.info("getClassLoader {*}", .{getClassLoader});
+        const cls = jni.invokeJni(.CallObjectMethod, .{ self.activity.clazz, getClassLoader });
+        std.log.info("class_loader instance {any}", .{cls});
+
+        const classLoader = jni.findClass("java/lang/ClassLoader");
+
+        const invocation_handler_class = jni.findClass("NativeInvocationHandler");
+        var result = jni.invokeJni(.ExceptionCheck, .{});
+        std.log.info("invocation_handler_class {any}, {}", .{ invocation_handler_class, result });
+        if (result != 0) jni.invokeJni(.ExceptionClear, .{});
+        const invocation_handler_class_full = jni.findClass("net/random_projects/zig_android_template/NativeInvocationHandler");
+        result = jni.invokeJni(.ExceptionCheck, .{});
+        std.log.info("invocation_handler_class_full {any}, {}", .{ invocation_handler_class_full, result });
+        if (result != 0) jni.invokeJni(.ExceptionClear, .{});
+        const invocation_handler_class_dot = jni.findClass("net.random_projects.zig_android_template.NativeInvocationHandler");
+        result = jni.invokeJni(.ExceptionCheck, .{});
+        std.log.info("invocation_handler_class_dot {any}, {}", .{ invocation_handler_class_dot, result });
+        if (result != 0) jni.invokeJni(.ExceptionClear, .{});
+
+        const getPackages = jni.invokeJni(.GetMethodID, .{ classLoader, "getPackages", "()[Ljava/lang/Package;" });
+        const packages = jni.invokeJni(.CallObjectMethod, .{ cls, getPackages });
+        const array_length = jni.invokeJni(.GetArrayLength, .{packages});
+        std.log.info("There are {} packages", .{array_length});
+
+        const findClass = jni.invokeJni(.GetMethodID, .{ classLoader, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;" });
+        const strClassName = jni.invokeJni(.NewStringUTF, .{"net/random_projects/zig_android_template/NativeInvocationHandler"});
+        const class = jni.invokeJni(.CallObjectMethod, .{ cls, findClass, strClassName });
+        jni.invokeJni(.DeleteLocalRef, .{strClassName});
+
+        // Get invocation handler factory
+        std.log.info("Creating invocation handler", .{});
+        self.invocation_handler = NativeInvocationHandler.init(jni, class);
+
+        // Create a TimerTask invoker
+        std.log.info("Creating timer task invoker", .{});
+        const TimerTaskInvoker = try self.invocation_handler.createAlloc(jni, self.allocator, null, &timerInvoke);
+
+        std.log.info("Creating proxy class", .{});
+        const Proxy = jni.findClass("java/lang/reflect/Proxy");
+        const newProxyInstance = jni.invokeJni(.GetMethodID, .{ Proxy, "newProxyInstance", "(Ljava/lang/reflect/ClassLoader;[Ljava/lang/Class;Ljava/lang/reflect/InvocationHandler;)" });
+
+        std.log.info("Creating Interface array", .{});
+        const interface_array = jni.invokeJni(.NewObjectArray, .{
+            1,
+            jni.findClass("java/lang/Class"),
+            jni.findClass("java/util/TimerTask"),
+        });
+
+        // Create the proxy object
+        std.log.info("Creating timer task proxy", .{});
+        const timer_task_proxy = jni.invokeJni(.CallStaticObjectMethod, .{ Proxy, newProxyInstance, cls, interface_array, TimerTaskInvoker });
+
+        std.log.info("Creating timer", .{});
+        const Timer = jni.findClass("java/util/Timer");
+        const timerInit = jni.invokeJni(.GetMethodID, .{ Timer, "<init>", "()V" });
+        const timer = jni.invokeJni(.NewObject, .{ Timer, timerInit });
+
+        std.log.info("Scheduling task", .{});
+        const schedule = jni.invokeJni(.GetMethodID, .{ Timer, "schedule", "(Ljava/util/TimerTask;J)V" });
+
+        const Long = jni.findClass("java/lang/Long");
+        const longInit = jni.invokeJni(.GetMethodID, .{ Long, "<init>", "(J)V" });
+        const delay: u64 = 10000;
+        const delay_long = jni.invokeJni(.NewObject, .{ Long, longInit, delay }) orelse return error.LongInit;
+
+        jni.invokeJni(.CallVoidMethod, .{ timer, schedule, timer_task_proxy, delay_long });
+    }
+};

--- a/examples/invocationhandler/main.zig
+++ b/examples/invocationhandler/main.zig
@@ -17,10 +17,17 @@ comptime {
 }
 
 pub fn timerInvoke(_: ?*anyopaque, jni: android.jni.JNI, method: android.jobject, args: android.jobjectArray) android.jobject {
-    _ = jni;
-    _ = method;
-    _ = args;
     std.log.info("Running invoke!", .{});
+    _ = method;
+    const length = jni.invokeJni(.GetArrayLength, .{args});
+    var i: i32 = 0;
+    while (i < length) : (i += 1) {
+        const object = jni.invokeJni(.GetObjectArrayElement, .{ args, i });
+        const string = android.jni.JNI.String.init(jni, jni.callObjectMethod(object, "toString", "()Ljava/lang/String;", .{}));
+        defer string.deinit(jni);
+        std.log.info("Arg {}: {}", .{ i, std.unicode.fmtUtf16le(string.slice) });
+    }
+
     return null;
 }
 

--- a/examples/textview/main.zig
+++ b/examples/textview/main.zig
@@ -4,7 +4,6 @@ const android = @import("android");
 
 const audio = android.audio;
 pub const panic = android.panic;
-pub const log = android.log;
 
 const EGLContext = android.egl.EGLContext;
 const JNI = android.JNI;
@@ -134,7 +133,7 @@ pub const AndroidApp = struct {
 
     fn setAppContentView(self: *AndroidApp) void {
         self.setAppContentViewImpl() catch |e| {
-            app_log.err("Error occured while running setAppContentView: {s}", .{ @errorName(e) });
+            app_log.err("Error occured while running setAppContentView: {s}", .{@errorName(e)});
         };
     }
 

--- a/src/NativeActivity.zig
+++ b/src/NativeActivity.zig
@@ -6,7 +6,7 @@ const Self = @This();
 
 activity: *android.ANativeActivity,
 jni: *android.JNI,
-activity_class: android.jclass,
+activity_class: android.JNI.Class,
 
 pub fn init(activity: *android.ANativeActivity) Self {
     var env: *android.JNIEnv = undefined;
@@ -22,11 +22,12 @@ pub fn get(activity: *android.ANativeActivity) Self {
 }
 
 fn fromJniEnv(activity: *android.ANativeActivity, env: *android.JNIEnv) Self {
-    var activityClass = env.*.FindClass(env, "android/app/NativeActivity");
+    var jni = @ptrCast(*android.JNI, env);
+    var activityClass = jni.findClass("android/app/NativeActivity") catch @panic("Could not get NativeActivity class");
 
     return Self{
         .activity = activity,
-        .jni = @ptrCast(*android.JNI, env),
+        .jni = jni,
         .activity_class = activityClass,
     };
 }
@@ -40,15 +41,12 @@ pub fn AndroidGetUnicodeChar(self: *Self, keyCode: c_int, metaState: c_int) !u21
     // https://stackoverflow.com/questions/21124051/receive-complete-android-unicode-input-in-c-c/43871301
     const eventType = android.AKEY_EVENT_ACTION_DOWN;
 
-    const class_key_event = try self.jni.findClass("android/view/KeyEvent");
+    const KeyEvent = try self.jni.findClass("android/view/KeyEvent");
 
-    const method_get_unicode_char = try self.jni.invokeJni(.GetMethodID, .{ class_key_event, "getUnicodeChar", "(I)I" });
-    const eventConstructor = try self.jni.invokeJni(.GetMethodID, .{ class_key_event, "<init>", "(II)V" });
-    const eventObj = try self.jni.invokeJni(.NewObject, .{ class_key_event, eventConstructor, eventType, keyCode });
+    const event_obj = try KeyEvent.newObject("(II)V", .{ eventType, keyCode });
+    const unicode_key = try KeyEvent.callIntMethod(event_obj, "getUnicodeChar", "(I)I", .{metaState});
 
-    const unicodeKey = try self.jni.invokeJni(.CallIntMethod, .{ eventObj, method_get_unicode_char, metaState });
-
-    return @intCast(u21, unicodeKey);
+    return @intCast(u21, unicode_key);
 }
 
 pub fn AndroidMakeFullscreen(self: *Self) !void {
@@ -57,52 +55,43 @@ pub fn AndroidMakeFullscreen(self: *Self) !void {
 
     // Get android.app.NativeActivity, then get getWindow method handle, returns
     // view.Window type
-    const activityClass = try self.jni.findClass("android/app/NativeActivity");
-    const getWindow = try self.jni.invokeJni(.GetMethodID, .{ activityClass, "getWindow", "()Landroid/view/Window;" });
-    const window = try self.jni.invokeJni(.CallObjectMethod, .{ self.activity.clazz, getWindow });
+    const ActivityClass = try self.jni.findClass("android/app/NativeActivity");
+    const window = try ActivityClass.callObjectMethod(self.activity.clazz, "getWindow", "()Landroid/view/Window;", .{});
 
     // Get android.view.Window class, then get getDecorView method handle, returns
     // view.View type
-    const windowClass = try self.jni.findClass("android/view/Window");
-    const getDecorView = try self.jni.invokeJni(.GetMethodID, .{ windowClass, "getDecorView", "()Landroid/view/View;" });
-    const decorView = try self.jni.invokeJni(.CallObjectMethod, .{ window, getDecorView });
+    const WindowClass = try self.jni.findClass("android/view/Window");
+    const decorView = try WindowClass.callObjectMethod(window, "getDecorView", "()Landroid/view/View;", .{});
 
     // Get the flag values associated with systemuivisibility
-    const viewClass = try self.jni.findClass("android/view/View");
-    const flagLayoutHideNavigation = try self.jni.invokeJni(.GetStaticIntField, .{ viewClass, try self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION", "I" }) });
-    const flagLayoutFullscreen = try self.jni.invokeJni(.GetStaticIntField, .{ viewClass, try self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN", "I" }) });
-    const flagLowProfile = try self.jni.invokeJni(.GetStaticIntField, .{ viewClass, try self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_LOW_PROFILE", "I" }) });
-    const flagHideNavigation = try self.jni.invokeJni(.GetStaticIntField, .{ viewClass, try self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_HIDE_NAVIGATION", "I" }) });
-    const flagFullscreen = try self.jni.invokeJni(.GetStaticIntField, .{ viewClass, try self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_FULLSCREEN", "I" }) });
-    const flagImmersiveSticky = try self.jni.invokeJni(.GetStaticIntField, .{ viewClass, try self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_IMMERSIVE_STICKY", "I" }) });
-
-    const setSystemUiVisibility = try self.jni.invokeJni(.GetMethodID, .{ viewClass, "setSystemUiVisibility", "(I)V" });
+    const ViewClass = try self.jni.findClass("android/view/View");
+    const flagLayoutHideNavigation = try ViewClass.getStaticIntField("SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION");
+    const flagLayoutFullscreen = try ViewClass.getStaticIntField("SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN");
+    const flagLowProfile = try ViewClass.getStaticIntField("SYSTEM_UI_FLAG_LOW_PROFILE");
+    const flagHideNavigation = try ViewClass.getStaticIntField("SYSTEM_UI_FLAG_HIDE_NAVIGATION");
+    const flagFullscreen = try ViewClass.getStaticIntField("SYSTEM_UI_FLAG_FULLSCREEN");
+    const flagImmersiveSticky = try ViewClass.getStaticIntField("SYSTEM_UI_FLAG_IMMERSIVE_STICKY");
 
     // Call the decorView.setSystemUiVisibility(FLAGS)
-    try self.jni.invokeJni(.CallVoidMethod, .{
-        decorView,
-        setSystemUiVisibility,
+    try ViewClass.callVoidMethod(decorView, "setSystemUiVisibility", "(I)V", .{
         (flagLayoutHideNavigation | flagLayoutFullscreen | flagLowProfile | flagHideNavigation | flagFullscreen | flagImmersiveSticky),
     });
 
     // now set some more flags associated with layoutmanager -- note the $ in the
     // class path search for api-versions.xml
     // https://android.googlesource.com/platform/development/+/refs/tags/android-9.0.0_r48/sdk/api-versions.xml
+    const LayoutManagerClass = try self.jni.findClass("android/view/WindowManager$LayoutParams");
+    const flag_WinMan_Fullscreen = try LayoutManagerClass.getStaticIntField("FLAG_FULLSCREEN");
+    const flag_WinMan_KeepScreenOn = try LayoutManagerClass.getStaticIntField("FLAG_KEEP_SCREEN_ON");
+    const flag_WinMan_hw_acc = try LayoutManagerClass.getStaticIntField("FLAG_HARDWARE_ACCELERATED");
 
-    const layoutManagerClass = try self.jni.findClass("android/view/WindowManager$LayoutParams");
-    const flag_WinMan_Fullscreen = try self.jni.invokeJni(.GetStaticIntField, .{ layoutManagerClass, try self.jni.invokeJni(.GetStaticFieldID, .{ layoutManagerClass, "FLAG_FULLSCREEN", "I" }) });
-    const flag_WinMan_KeepScreenOn = try self.jni.invokeJni(.GetStaticIntField, .{ layoutManagerClass, try self.jni.invokeJni(.GetStaticFieldID, .{ layoutManagerClass, "FLAG_KEEP_SCREEN_ON", "I" }) });
-    const flag_WinMan_hw_acc = try self.jni.invokeJni(.GetStaticIntField, .{ layoutManagerClass, try self.jni.invokeJni(.GetStaticFieldID, .{ layoutManagerClass, "FLAG_HARDWARE_ACCELERATED", "I" }) });
     //    const int flag_WinMan_flag_not_fullscreen =
     //    env.GetStaticIntField(layoutManagerClass,
     //    (env.GetStaticFieldID(layoutManagerClass, "FLAG_FORCE_NOT_FULLSCREEN",
     //    "I") ));
     // call window.addFlags(FLAGS)
-    try self.jni.invokeJni(.CallVoidMethod, .{
-        window,
-        try self.jni.invokeJni(.GetMethodID, .{ windowClass, "addFlags", "(I)V" }),
-        (flag_WinMan_Fullscreen | flag_WinMan_KeepScreenOn | flag_WinMan_hw_acc),
-    });
+
+    try WindowClass.callVoidMethod(window, "addFlags", "(I)V", .{(flag_WinMan_Fullscreen | flag_WinMan_KeepScreenOn | flag_WinMan_hw_acc)});
 }
 
 pub fn AndroidDisplayKeyboard(self: *Self, show: bool) !bool {
@@ -112,34 +101,27 @@ pub fn AndroidDisplayKeyboard(self: *Self, show: bool) !bool {
 
     // Retrieves Context.INPUT_METHOD_SERVICE.
     const ClassContext = try self.jni.findClass("android/content/Context");
-    const FieldINPUT_METHOD_SERVICE = try self.jni.invokeJni(.GetStaticFieldID, .{ ClassContext, "INPUT_METHOD_SERVICE", "Ljava/lang/String;" });
-    const INPUT_METHOD_SERVICE = try self.jni.invokeJni(.GetStaticObjectField, .{ ClassContext, FieldINPUT_METHOD_SERVICE });
+    const INPUT_METHOD_SERVICE = try ClassContext.getStaticObjectField("INPUT_METHOD_SERVICE", "Ljava/lang/String;");
 
     // Runs getSystemService(Context.INPUT_METHOD_SERVICE).
     const ClassInputMethodManager = try self.jni.findClass("android/view/inputmethod/InputMethodManager");
-    const MethodGetSystemService = try self.jni.invokeJni(.GetMethodID, .{ self.activity_class, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;" });
-    const lInputMethodManager = try self.jni.invokeJni(.CallObjectMethod, .{ self.activity.clazz, MethodGetSystemService, INPUT_METHOD_SERVICE });
+    const lInputMethodManager = try ClassInputMethodManager.callObjectMethod(self.activity.clazz, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;", .{INPUT_METHOD_SERVICE});
 
     // Runs getWindow().getDecorView().
-    const MethodGetWindow = try self.jni.invokeJni(.GetMethodID, .{ self.activity_class, "getWindow", "()Landroid/view/Window;" });
-    const lWindow = try self.jni.invokeJni(.CallObjectMethod, .{ self.activity.clazz, MethodGetWindow });
+    const lWindow = try ClassContext.callObjectMethod(self.activity.clazz, "getWindow", "()Landroid/view/Window;", .{});
     const ClassWindow = try self.jni.findClass("android/view/Window");
-    const MethodGetDecorView = try self.jni.invokeJni(.GetMethodID, .{ ClassWindow, "getDecorView", "()Landroid/view/View;" });
-    const lDecorView = try self.jni.invokeJni(.CallObjectMethod, .{ lWindow, MethodGetDecorView });
+    const lDecorView = try ClassWindow.callObjectMethod(lWindow, "getDecorView", "()Landroid/view/View;", .{});
 
     if (show) {
         // Runs lInputMethodManager.showSoftInput(...).
-        const MethodShowSoftInput = try self.jni.invokeJni(.GetMethodID, .{ ClassInputMethodManager, "showSoftInput", "(Landroid/view/View;I)Z" });
-        return 0 != try self.jni.invokeJni(.CallBooleanMethod, .{ lInputMethodManager, MethodShowSoftInput, lDecorView, lFlags });
+        return ClassInputMethodManager.callBooleanMethod(lInputMethodManager, "showSoftInput", "(Landroid/view/View;I)Z", .{ lDecorView, lFlags });
     } else {
         // Runs lWindow.getViewToken()
         const ClassView = try self.jni.findClass("android/view/View");
-        const MethodGetWindowToken = try self.jni.invokeJni(.GetMethodID, .{ ClassView, "getWindowToken", "()Landroid/os/IBinder;" });
-        const lBinder = try self.jni.invokeJni(.CallObjectMethod, .{ lDecorView, MethodGetWindowToken });
+        const lBinder = try ClassView.callObjectMethod(lDecorView, "getWindowToken", "()Landroid/os/IBinder;", .{});
 
         // lInputMethodManager.hideSoftInput(...).
-        const MethodHideSoftInput = try self.jni.invokeJni(.GetMethodID, .{ ClassInputMethodManager, "hideSoftInputFromWindow", "(Landroid/os/IBinder;I)Z" });
-        return 0 != try self.jni.invokeJni(.CallBooleanMethod, .{ lInputMethodManager, MethodHideSoftInput, lBinder, lFlags });
+        return ClassInputMethodManager.callBooleanMethod(lInputMethodManager, "hideSoftInputFromWindow", "(Landroid/os/IBinder;I)Z", .{ lBinder, lFlags });
     }
 }
 
@@ -149,9 +131,7 @@ pub fn AndroidDisplayKeyboard(self: *Self, show: bool) !bool {
 /// returns: If the task was moved (or it was already at the back) true is returned, else false.
 pub fn AndroidSendToBack(self: *Self, nonRoot: bool) !bool {
     const ClassActivity = try self.jni.findClass("android/app/Activity");
-    const MethodmoveTaskToBack = try self.jni.invokeJni(.GetMethodID, .{ ClassActivity, "moveTaskToBack", "(Z)Z" });
-
-    return 0 != try self.jni.invokeJni(.CallBooleanMethod, .{ self.activity.clazz, MethodmoveTaskToBack, if (nonRoot) @as(c_int, 1) else 0 });
+    return ClassActivity.callBooleanMethod(self.activity.clazz, "moveTaskToBack", "(Z)Z", .{if (nonRoot) @as(c_int, 1) else 0});
 }
 
 pub fn AndroidHasPermissions(self: *Self, perm_name: [:0]const u8) !bool {
@@ -163,17 +143,15 @@ pub fn AndroidHasPermissions(self: *Self, perm_name: [:0]const u8) !bool {
         return false;
     }
 
-    const ls_PERM = try self.jni.invokeJni(.NewStringUTF, .{perm_name});
+    const ls_PERM = try self.jni.newString(perm_name);
 
     const PERMISSION_GRANTED = blk: {
         var ClassPackageManager = try self.jni.findClass("android/content/pm/PackageManager");
-        var lid_PERMISSION_GRANTED = try self.jni.invokeJni(.GetStaticFieldID, .{ ClassPackageManager, "PERMISSION_GRANTED", "I" });
-        break :blk try self.jni.invokeJni(.GetStaticIntField, .{ ClassPackageManager, lid_PERMISSION_GRANTED });
+        break :blk try ClassPackageManager.getStaticIntField("PERMISSION_GRANTED");
     };
 
     const ClassContext = try self.jni.findClass("android/content/Context");
-    const MethodcheckSelfPermission = try self.jni.invokeJni(.GetMethodID, .{ ClassContext, "checkSelfPermission", "(Ljava/lang/String;)I" });
-    const int_result = try self.jni.invokeJni(.CallIntMethod, .{ self.activity.clazz, MethodcheckSelfPermission, ls_PERM });
+    const int_result = try ClassContext.callIntMethod(self.activity.clazz, "checkSelfPermission", "(Ljava/lang/String;)I", .{ls_PERM});
     return (int_result == PERMISSION_GRANTED);
 }
 
@@ -188,26 +166,20 @@ pub fn AndroidRequestAppPermissions(self: *Self, perm_name: [:0]const u8) !void 
 
     const perm_array = try self.jni.invokeJni(.NewObjectArray, .{
         1,
-        try self.jni.findClass("java/lang/String"),
-        try self.jni.invokeJni(.NewStringUTF, .{perm_name}),
+        try self.jni.invokeJni(.FindClass, .{"java/lang/String"}),
+        try self.jni.newString(perm_name),
     });
 
-    const MethodrequestPermissions = try self.jni.invokeJni(.GetMethodID, .{ self.activity_class, "requestPermissions", "([Ljava/lang/String;I)V" });
-
     // Last arg (0) is just for the callback (that I do not use)
-    try self.jni.invokeJni(.CallVoidMethod, .{ self.activity.clazz, MethodrequestPermissions, perm_array, @as(c_int, 0) });
+    try self.activity_class.callVoidMethod(self.activity.clazz, "requestPermissions", "([Ljava/lang/String;I)V", .{ perm_array, @as(c_int, 0) });
 }
 
 pub fn getFilesDir(self: *Self, allocator: std.mem.Allocator) ![:0]const u8 {
-    const getFilesDirMethod = try self.jni.invokeJni(.GetMethodID, .{ self.activity_class, "getFilesDir", "()Ljava/io/File;" });
+    const files_dir = try self.activity_class.callVoidMethod(self.activity.clazz, "getFilesDir", "()Ljava/io/File;", .{});
 
-    const files_dir = try self.jni.*.CallObjectMethod(try self.jni, self.activity.clazz, getFilesDirMethod);
+    const FileClass = try self.jni.findClass("java/io/File");
 
-    const fileClass = try self.jni.findClass("java/io/File");
-
-    const getPathMethod = try self.jni.invokeJni(.GetMethodID, .{ fileClass, "getPath", "()Ljava/lang/String;" });
-
-    const path_string = try self.jni.*.CallObjectMethod(try self.jni, files_dir, getPathMethod);
+    const path_string = try FileClass.callObjectMethod(files_dir, "getPath", "()Ljava/lang/String;", .{});
 
     const utf8_or_null = try self.jni.invokeJni(.GetStringUTFChars, .{ path_string, null });
 

--- a/src/NativeActivity.zig
+++ b/src/NativeActivity.zig
@@ -1,0 +1,232 @@
+const std = @import("std");
+const log = std.log.scoped(.jni);
+const android = @import("android-support.zig");
+
+const Self = @This();
+
+activity: *android.ANativeActivity,
+jni: *android.JNI,
+activity_class: android.jclass,
+
+pub fn init(activity: *android.ANativeActivity) Self {
+    var env: *android.JNIEnv = undefined;
+    _ = activity.vm.*.AttachCurrentThread(activity.vm, &env, null);
+    return fromJniEnv(activity, env);
+}
+
+/// Get the JNIEnv associated with the current thread.
+pub fn get(activity: *android.ANativeActivity) Self {
+    var env: *android.JNIEnv = undefined;
+    _ = activity.vm.*.GetEnv(activity.vm, @ptrCast(*?*anyopaque, &env), android.JNI_VERSION_1_6);
+    return fromJniEnv(activity, env);
+}
+
+fn fromJniEnv(activity: *android.ANativeActivity, env: *android.JNIEnv) Self {
+    var activityClass = env.*.FindClass(env, "android/app/NativeActivity");
+
+    return Self{
+        .activity = activity,
+        .jni = @ptrCast(*android.JNI, env),
+        .activity_class = activityClass,
+    };
+}
+
+pub fn deinit(self: *Self) void {
+    _ = self.activity.vm.*.DetachCurrentThread(self.activity.vm);
+    self.* = undefined;
+}
+
+pub fn AndroidGetUnicodeChar(self: *Self, keyCode: c_int, metaState: c_int) !u21 {
+    // https://stackoverflow.com/questions/21124051/receive-complete-android-unicode-input-in-c-c/43871301
+    const eventType = android.AKEY_EVENT_ACTION_DOWN;
+
+    const class_key_event = try self.jni.findClass("android/view/KeyEvent");
+
+    const method_get_unicode_char = try self.jni.invokeJni(.GetMethodID, .{ class_key_event, "getUnicodeChar", "(I)I" });
+    const eventConstructor = try self.jni.invokeJni(.GetMethodID, .{ class_key_event, "<init>", "(II)V" });
+    const eventObj = try self.jni.invokeJni(.NewObject, .{ class_key_event, eventConstructor, eventType, keyCode });
+
+    const unicodeKey = try self.jni.invokeJni(.CallIntMethod, .{ eventObj, method_get_unicode_char, metaState });
+
+    return @intCast(u21, unicodeKey);
+}
+
+pub fn AndroidMakeFullscreen(self: *Self) !void {
+    // Partially based on
+    // https://stackoverflow.com/questions/47507714/how-do-i-enable-full-screen-immersive-mode-for-a-native-activity-ndk-app
+
+    // Get android.app.NativeActivity, then get getWindow method handle, returns
+    // view.Window type
+    const activityClass = try self.jni.findClass("android/app/NativeActivity");
+    const getWindow = try self.jni.invokeJni(.GetMethodID, .{ activityClass, "getWindow", "()Landroid/view/Window;" });
+    const window = try self.jni.invokeJni(.CallObjectMethod, .{ self.activity.clazz, getWindow });
+
+    // Get android.view.Window class, then get getDecorView method handle, returns
+    // view.View type
+    const windowClass = try self.jni.findClass("android/view/Window");
+    const getDecorView = try self.jni.invokeJni(.GetMethodID, .{ windowClass, "getDecorView", "()Landroid/view/View;" });
+    const decorView = try self.jni.invokeJni(.CallObjectMethod, .{ window, getDecorView });
+
+    // Get the flag values associated with systemuivisibility
+    const viewClass = try self.jni.findClass("android/view/View");
+    const flagLayoutHideNavigation = try self.jni.invokeJni(.GetStaticIntField, .{ viewClass, try self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION", "I" }) });
+    const flagLayoutFullscreen = try self.jni.invokeJni(.GetStaticIntField, .{ viewClass, try self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN", "I" }) });
+    const flagLowProfile = try self.jni.invokeJni(.GetStaticIntField, .{ viewClass, try self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_LOW_PROFILE", "I" }) });
+    const flagHideNavigation = try self.jni.invokeJni(.GetStaticIntField, .{ viewClass, try self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_HIDE_NAVIGATION", "I" }) });
+    const flagFullscreen = try self.jni.invokeJni(.GetStaticIntField, .{ viewClass, try self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_FULLSCREEN", "I" }) });
+    const flagImmersiveSticky = try self.jni.invokeJni(.GetStaticIntField, .{ viewClass, try self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_IMMERSIVE_STICKY", "I" }) });
+
+    const setSystemUiVisibility = try self.jni.invokeJni(.GetMethodID, .{ viewClass, "setSystemUiVisibility", "(I)V" });
+
+    // Call the decorView.setSystemUiVisibility(FLAGS)
+    try self.jni.invokeJni(.CallVoidMethod, .{
+        decorView,
+        setSystemUiVisibility,
+        (flagLayoutHideNavigation | flagLayoutFullscreen | flagLowProfile | flagHideNavigation | flagFullscreen | flagImmersiveSticky),
+    });
+
+    // now set some more flags associated with layoutmanager -- note the $ in the
+    // class path search for api-versions.xml
+    // https://android.googlesource.com/platform/development/+/refs/tags/android-9.0.0_r48/sdk/api-versions.xml
+
+    const layoutManagerClass = try self.jni.findClass("android/view/WindowManager$LayoutParams");
+    const flag_WinMan_Fullscreen = try self.jni.invokeJni(.GetStaticIntField, .{ layoutManagerClass, try self.jni.invokeJni(.GetStaticFieldID, .{ layoutManagerClass, "FLAG_FULLSCREEN", "I" }) });
+    const flag_WinMan_KeepScreenOn = try self.jni.invokeJni(.GetStaticIntField, .{ layoutManagerClass, try self.jni.invokeJni(.GetStaticFieldID, .{ layoutManagerClass, "FLAG_KEEP_SCREEN_ON", "I" }) });
+    const flag_WinMan_hw_acc = try self.jni.invokeJni(.GetStaticIntField, .{ layoutManagerClass, try self.jni.invokeJni(.GetStaticFieldID, .{ layoutManagerClass, "FLAG_HARDWARE_ACCELERATED", "I" }) });
+    //    const int flag_WinMan_flag_not_fullscreen =
+    //    env.GetStaticIntField(layoutManagerClass,
+    //    (env.GetStaticFieldID(layoutManagerClass, "FLAG_FORCE_NOT_FULLSCREEN",
+    //    "I") ));
+    // call window.addFlags(FLAGS)
+    try self.jni.invokeJni(.CallVoidMethod, .{
+        window,
+        try self.jni.invokeJni(.GetMethodID, .{ windowClass, "addFlags", "(I)V" }),
+        (flag_WinMan_Fullscreen | flag_WinMan_KeepScreenOn | flag_WinMan_hw_acc),
+    });
+}
+
+pub fn AndroidDisplayKeyboard(self: *Self, show: bool) !bool {
+    // Based on
+    // https://stackoverflow.com/questions/5864790/how-to-show-the-soft-keyboard-on-native-activity
+    var lFlags: android.jint = 0;
+
+    // Retrieves Context.INPUT_METHOD_SERVICE.
+    const ClassContext = try self.jni.findClass("android/content/Context");
+    const FieldINPUT_METHOD_SERVICE = try self.jni.invokeJni(.GetStaticFieldID, .{ ClassContext, "INPUT_METHOD_SERVICE", "Ljava/lang/String;" });
+    const INPUT_METHOD_SERVICE = try self.jni.invokeJni(.GetStaticObjectField, .{ ClassContext, FieldINPUT_METHOD_SERVICE });
+
+    // Runs getSystemService(Context.INPUT_METHOD_SERVICE).
+    const ClassInputMethodManager = try self.jni.findClass("android/view/inputmethod/InputMethodManager");
+    const MethodGetSystemService = try self.jni.invokeJni(.GetMethodID, .{ self.activity_class, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;" });
+    const lInputMethodManager = try self.jni.invokeJni(.CallObjectMethod, .{ self.activity.clazz, MethodGetSystemService, INPUT_METHOD_SERVICE });
+
+    // Runs getWindow().getDecorView().
+    const MethodGetWindow = try self.jni.invokeJni(.GetMethodID, .{ self.activity_class, "getWindow", "()Landroid/view/Window;" });
+    const lWindow = try self.jni.invokeJni(.CallObjectMethod, .{ self.activity.clazz, MethodGetWindow });
+    const ClassWindow = try self.jni.findClass("android/view/Window");
+    const MethodGetDecorView = try self.jni.invokeJni(.GetMethodID, .{ ClassWindow, "getDecorView", "()Landroid/view/View;" });
+    const lDecorView = try self.jni.invokeJni(.CallObjectMethod, .{ lWindow, MethodGetDecorView });
+
+    if (show) {
+        // Runs lInputMethodManager.showSoftInput(...).
+        const MethodShowSoftInput = try self.jni.invokeJni(.GetMethodID, .{ ClassInputMethodManager, "showSoftInput", "(Landroid/view/View;I)Z" });
+        return 0 != try self.jni.invokeJni(.CallBooleanMethod, .{ lInputMethodManager, MethodShowSoftInput, lDecorView, lFlags });
+    } else {
+        // Runs lWindow.getViewToken()
+        const ClassView = try self.jni.findClass("android/view/View");
+        const MethodGetWindowToken = try self.jni.invokeJni(.GetMethodID, .{ ClassView, "getWindowToken", "()Landroid/os/IBinder;" });
+        const lBinder = try self.jni.invokeJni(.CallObjectMethod, .{ lDecorView, MethodGetWindowToken });
+
+        // lInputMethodManager.hideSoftInput(...).
+        const MethodHideSoftInput = try self.jni.invokeJni(.GetMethodID, .{ ClassInputMethodManager, "hideSoftInputFromWindow", "(Landroid/os/IBinder;I)Z" });
+        return 0 != try self.jni.invokeJni(.CallBooleanMethod, .{ lInputMethodManager, MethodHideSoftInput, lBinder, lFlags });
+    }
+}
+
+/// Move the task containing this activity to the back of the activity stack.
+/// The activity's order within the task is unchanged.
+/// nonRoot: If false then this only works if the activity is the root of a task; if true it will work for any activity in a task.
+/// returns: If the task was moved (or it was already at the back) true is returned, else false.
+pub fn AndroidSendToBack(self: *Self, nonRoot: bool) !bool {
+    const ClassActivity = try self.jni.findClass("android/app/Activity");
+    const MethodmoveTaskToBack = try self.jni.invokeJni(.GetMethodID, .{ ClassActivity, "moveTaskToBack", "(Z)Z" });
+
+    return 0 != try self.jni.invokeJni(.CallBooleanMethod, .{ self.activity.clazz, MethodmoveTaskToBack, if (nonRoot) @as(c_int, 1) else 0 });
+}
+
+pub fn AndroidHasPermissions(self: *Self, perm_name: [:0]const u8) !bool {
+    if (android.sdk_version < 23) {
+        log.err(
+            "Android SDK version {} does not support AndroidRequestAppPermissions\n",
+            .{android.sdk_version},
+        );
+        return false;
+    }
+
+    const ls_PERM = try self.jni.invokeJni(.NewStringUTF, .{perm_name});
+
+    const PERMISSION_GRANTED = blk: {
+        var ClassPackageManager = try self.jni.findClass("android/content/pm/PackageManager");
+        var lid_PERMISSION_GRANTED = try self.jni.invokeJni(.GetStaticFieldID, .{ ClassPackageManager, "PERMISSION_GRANTED", "I" });
+        break :blk try self.jni.invokeJni(.GetStaticIntField, .{ ClassPackageManager, lid_PERMISSION_GRANTED });
+    };
+
+    const ClassContext = try self.jni.findClass("android/content/Context");
+    const MethodcheckSelfPermission = try self.jni.invokeJni(.GetMethodID, .{ ClassContext, "checkSelfPermission", "(Ljava/lang/String;)I" });
+    const int_result = try self.jni.invokeJni(.CallIntMethod, .{ self.activity.clazz, MethodcheckSelfPermission, ls_PERM });
+    return (int_result == PERMISSION_GRANTED);
+}
+
+pub fn AndroidRequestAppPermissions(self: *Self, perm_name: [:0]const u8) !void {
+    if (android.sdk_version < 23) {
+        log.err(
+            "Android SDK version {} does not support AndroidRequestAppPermissions\n",
+            .{android.sdk_version},
+        );
+        return;
+    }
+
+    const perm_array = try self.jni.invokeJni(.NewObjectArray, .{
+        1,
+        try self.jni.findClass("java/lang/String"),
+        try self.jni.invokeJni(.NewStringUTF, .{perm_name}),
+    });
+
+    const MethodrequestPermissions = try self.jni.invokeJni(.GetMethodID, .{ self.activity_class, "requestPermissions", "([Ljava/lang/String;I)V" });
+
+    // Last arg (0) is just for the callback (that I do not use)
+    try self.jni.invokeJni(.CallVoidMethod, .{ self.activity.clazz, MethodrequestPermissions, perm_array, @as(c_int, 0) });
+}
+
+pub fn getFilesDir(self: *Self, allocator: std.mem.Allocator) ![:0]const u8 {
+    const getFilesDirMethod = try self.jni.invokeJni(.GetMethodID, .{ self.activity_class, "getFilesDir", "()Ljava/io/File;" });
+
+    const files_dir = try self.jni.*.CallObjectMethod(try self.jni, self.activity.clazz, getFilesDirMethod);
+
+    const fileClass = try self.jni.findClass("java/io/File");
+
+    const getPathMethod = try self.jni.invokeJni(.GetMethodID, .{ fileClass, "getPath", "()Ljava/lang/String;" });
+
+    const path_string = try self.jni.*.CallObjectMethod(try self.jni, files_dir, getPathMethod);
+
+    const utf8_or_null = try self.jni.invokeJni(.GetStringUTFChars, .{ path_string, null });
+
+    if (utf8_or_null) |utf8_ptr| {
+        defer self.jni.invokeJniNoException(.ReleaseStringUTFChars, .{ path_string, utf8_ptr });
+
+        const utf8 = std.mem.sliceTo(utf8_ptr, 0);
+
+        return try allocator.dupeZ(u8, utf8);
+    } else {
+        return error.OutOfMemory;
+    }
+}
+
+comptime {
+    _ = AndroidGetUnicodeChar;
+    _ = AndroidMakeFullscreen;
+    _ = AndroidDisplayKeyboard;
+    _ = AndroidSendToBack;
+    _ = AndroidHasPermissions;
+    _ = AndroidRequestAppPermissions;
+}

--- a/src/NativeInvocationHandler.java
+++ b/src/NativeInvocationHandler.java
@@ -1,0 +1,15 @@
+import java.lang.Object;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+public class NativeInvocationHandler implements InvocationHandler {
+  public NativeInvocationHandler(long ptr) { this.ptr = ptr; }
+
+  public Object invoke(Object proxy, Method method, Object[] args) {
+    return invoke0(proxy, method, args);
+  }
+
+  native private Object invoke0(Object proxy, Method method, Object[] args);
+
+  private long ptr;
+}

--- a/src/NativeInvocationHandler.zig
+++ b/src/NativeInvocationHandler.zig
@@ -5,7 +5,7 @@ const Self = @This();
 class: android.jobject,
 initFn: android.jmethodID,
 
-pub fn init(jni: *android.jni.JNI, class: android.jobject) Self {
+pub fn init(jni: *android.JNI, class: android.jobject) !Self {
     const methods = [_]android.JNINativeMethod{
         .{
             .name = "invoke0",
@@ -13,14 +13,14 @@ pub fn init(jni: *android.jni.JNI, class: android.jobject) Self {
             .fnPtr = InvocationHandler.invoke0,
         },
     };
-    _ = jni.invokeJni(.RegisterNatives, .{ class, &methods, methods.len });
+    _ = try jni.invokeJni(.RegisterNatives, .{ class, &methods, methods.len });
     return Self{
         .class = class,
-        .initFn = jni.invokeJni(.GetMethodID, .{ class, "<init>", "(J)V" }),
+        .initFn = try jni.invokeJni(.GetMethodID, .{ class, "<init>", "(J)V" }),
     };
 }
 
-pub fn createAlloc(self: Self, jni: *android.jni.JNI, alloc: std.mem.Allocator, pointer: ?*anyopaque, function: InvokeFn) !android.jobject {
+pub fn createAlloc(self: Self, jni: *android.JNI, alloc: std.mem.Allocator, pointer: ?*anyopaque, function: InvokeFn) !android.jobject {
     // Create a InvocationHandler struct
     var handler = try alloc.create(InvocationHandler);
     errdefer alloc.destroy(handler);
@@ -33,16 +33,14 @@ pub fn createAlloc(self: Self, jni: *android.jni.JNI, alloc: std.mem.Allocator, 
     std.debug.assert(handler_value <= 0x7fffffffffffffff);
 
     // Call handler constructor
-    const result = jni.invokeJni(.NewObject, .{ self.class, self.initFn, handler_value }) orelse return error.InvocationHandlerInitError;
-    // if (result != null) return error.InvocationHandlerInitError;
-    // _ = result;
+    const result = try jni.invokeJni(.NewObject, .{ self.class, self.initFn, handler_value }) orelse return error.InvocationHandlerInitError;
     return result;
 
     // return handler;
 }
 
 /// Function signature for invoke functions
-pub const InvokeFn = *const fn (?*anyopaque, *android.jni.JNI, android.jobject, android.jobjectArray) android.jobject;
+pub const InvokeFn = *const fn (?*anyopaque, *android.JNI, android.jobject, android.jobjectArray) anyerror!android.jobject;
 
 /// InvocationHandler Technique found here https://groups.google.com/g/android-ndk/c/SRgy93Un8vM
 const InvocationHandler = struct {
@@ -50,11 +48,17 @@ const InvocationHandler = struct {
     function: InvokeFn,
 
     /// Called by java class NativeInvocationHandler
-    pub fn invoke0(jni: *android.jni.JNI, this: android.jobject, proxy: android.jobject, method: android.jobject, args: android.jobjectArray) android.jobject {
+    pub fn invoke0(jni: *android.JNI, this: android.jobject, proxy: android.jobject, method: android.jobject, args: android.jobjectArray) android.jobject {
+        return invoke_impl(jni, this, proxy, method, args) catch |e| switch (e) {
+            else => @panic(@errorName(e)),
+        };
+    }
+
+    fn invoke_impl(jni: *android.JNI, this: android.jobject, proxy: android.jobject, method: android.jobject, args: android.jobjectArray) anyerror!android.jobject {
         _ = proxy; // This is the proxy object. Calling anything on it will cause invoke to be called. If this isn't explicitly handled, it will recurse infinitely
-        const Class = jni.invokeJni(.GetObjectClass, .{this});
-        const ptrField = jni.invokeJni(.GetFieldID, .{ Class, "ptr", "J" });
-        const jptr = jni.getLongField(this, ptrField);
+        const Class = try jni.invokeJni(.GetObjectClass, .{this});
+        const ptrField = try jni.invokeJni(.GetFieldID, .{ Class, "ptr", "J" });
+        const jptr = try jni.getLongField(this, ptrField);
         const h = @intToPtr(*InvocationHandler, @intCast(usize, jptr));
         return h.function(h.pointer, jni, method, args);
     }

--- a/src/android-bind.zig
+++ b/src/android-bind.zig
@@ -512,7 +512,7 @@ pub const jobjectRefType = enum_jobjectRefType;
 const struct_unnamed_15 = extern struct {
     name: [*c]const u8,
     signature: [*c]const u8,
-    fnPtr: ?*anyopaque,
+    fnPtr: ?*const anyopaque,
 };
 pub const JNINativeMethod = struct_unnamed_15;
 pub const JNINativeInterface = extern struct {

--- a/src/android-support.zig
+++ b/src/android-support.zig
@@ -7,7 +7,7 @@ const android = @import("android-bind.zig");
 const build_options = @import("build_options");
 
 pub const egl = @import("egl.zig");
-pub const JNI = @import("jni.zig").JNI;
+pub const jni = @import("jni.zig");
 pub const audio = @import("audio.zig");
 pub const NativeInvocationHandler = @import("native-invocation-handler.zig");
 

--- a/src/android-support.zig
+++ b/src/android-support.zig
@@ -7,9 +7,10 @@ const android = @import("android-bind.zig");
 const build_options = @import("build_options");
 
 pub const egl = @import("egl.zig");
-pub const jni = @import("jni.zig");
+pub const JNI = @import("jni.zig").JNI;
 pub const audio = @import("audio.zig");
-pub const NativeInvocationHandler = @import("native-invocation-handler.zig");
+pub const NativeActivity = @import("NativeActivity.zig");
+pub const NativeInvocationHandler = @import("NativeInvocationHandler.zig");
 
 const app_log = std.log.scoped(.app_glue);
 

--- a/src/android-support.zig
+++ b/src/android-support.zig
@@ -9,6 +9,7 @@ const build_options = @import("build_options");
 pub const egl = @import("egl.zig");
 pub const JNI = @import("jni.zig").JNI;
 pub const audio = @import("audio.zig");
+pub const NativeInvocationHandler = @import("native-invocation-handler.zig");
 
 const app_log = std.log.scoped(.app_glue);
 

--- a/src/jni.zig
+++ b/src/jni.zig
@@ -5,36 +5,16 @@ const android = @import("android-support.zig");
 pub const JNI = struct {
     const Self = @This();
 
-    activity: *android.ANativeActivity,
     env: *android.JNIEnv,
-    activity_class: android.jclass,
 
-    pub fn init(activity: *android.ANativeActivity) Self {
-        var env: *android.JNIEnv = undefined;
-        _ = activity.vm.*.AttachCurrentThread(activity.vm, &env, null);
-        return fromJniEnv(activity, env);
-    }
-
-    /// Get the JNIEnv associated with the current thread.
-    pub fn get(activity: *android.ANativeActivity) Self {
-        var env: *android.JNIEnv = undefined;
-        _ = activity.vm.*.GetEnv(activity.vm, @ptrCast(*?*anyopaque, &env), android.JNI_VERSION_1_6);
-        return fromJniEnv(activity, env);
-    }
-
-    fn fromJniEnv(activity: *android.ANativeActivity, env: *android.JNIEnv) Self {
-        var activityClass = env.*.FindClass(env, "android/app/NativeActivity");
-
+    pub fn init(env: *android.JNIEnv) Self {
         return Self{
-            .activity = activity,
             .env = env,
-            .activity_class = activityClass,
         };
     }
 
-    pub fn deinit(self: *Self) void {
-        _ = self.activity.vm.*.DetachCurrentThread(self.activity.vm);
-        self.* = undefined;
+    pub fn findClass(self: Self, class: [:0]const u8) android.jclass {
+        return self.invokeJni(.FindClass, .{class.ptr});
     }
 
     fn JniReturnType(comptime function: @TypeOf(.literal)) type {
@@ -49,9 +29,20 @@ pub const JNI = struct {
             .{self.env} ++ args,
         );
     }
+    pub fn getClassNameString(self: Self, object: android.jobject) String {
+        const object_class = self.invokeJni(.GetObjectClass, .{object});
+        const ClassClass = self.findClass("java/lang/Class");
+        const getName = self.invokeJni(.GetMethodID, .{ ClassClass, "getName", "()Ljava/lang/String;" });
+        const name = self.invokeJni(.CallObjectMethod, .{ object_class, getName });
+        return String.init(self, name);
+    }
 
-    pub fn findClass(self: Self, class: [:0]const u8) android.jclass {
-        return self.invokeJni(.FindClass, .{class.ptr});
+    pub fn newString(self: Self, string: [*:0]const u8) android.jstring {
+        return self.invokeJni(.NewStringUTF, .{string});
+    }
+
+    pub fn getLongField(self: Self, object: android.jobject, field_id: android.jfieldID) android.jlong {
+        return self.invokeJni(.GetLongField, .{ object, field_id });
     }
 
     pub const String = struct {
@@ -72,30 +63,54 @@ pub const JNI = struct {
             self.invokeJni(.ReleaseStringChars, .{ string.jstring, string.slice.ptr });
         }
     };
+};
 
-    pub fn getClassNameString(self: Self, object: android.jobject) String {
-        const object_class = self.invokeJni(.GetObjectClass, .{object});
-        const ClassClass = self.findClass("java/lang/Class");
-        const getName = self.invokeJni(.GetMethodID, .{ ClassClass, "getName", "()Ljava/lang/String;" });
-        const name = self.invokeJni(.CallObjectMethod, .{ object_class, getName });
-        return String.init(self, name);
+pub const NativeActivity = struct {
+    const Self = @This();
+
+    activity: *android.ANativeActivity,
+    jni: JNI,
+    activity_class: android.jclass,
+
+    pub fn init(activity: *android.ANativeActivity) Self {
+        var env: *android.JNIEnv = undefined;
+        _ = activity.vm.*.AttachCurrentThread(activity.vm, &env, null);
+        return fromJniEnv(activity, env);
     }
 
-    pub fn newString(self: Self, string: [*:0]const u8) android.jstring {
-        return self.invokeJni(.NewStringUTF, .{string});
+    /// Get the JNIEnv associated with the current thread.
+    pub fn get(activity: *android.ANativeActivity) Self {
+        var env: *android.JNIEnv = undefined;
+        _ = activity.vm.*.GetEnv(activity.vm, @ptrCast(*?*anyopaque, &env), android.JNI_VERSION_1_6);
+        return fromJniEnv(activity, env);
+    }
+
+    fn fromJniEnv(activity: *android.ANativeActivity, env: *android.JNIEnv) Self {
+        var activityClass = env.*.FindClass(env, "android/app/NativeActivity");
+
+        return Self{
+            .activity = activity,
+            .jni = JNI.init(env),
+            .activity_class = activityClass,
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        _ = self.activity.vm.*.DetachCurrentThread(self.activity.vm);
+        self.* = undefined;
     }
 
     pub fn AndroidGetUnicodeChar(self: *Self, keyCode: c_int, metaState: c_int) u21 {
         // https://stackoverflow.com/questions/21124051/receive-complete-android-unicode-input-in-c-c/43871301
         const eventType = android.AKEY_EVENT_ACTION_DOWN;
 
-        const class_key_event = self.findClass("android/view/KeyEvent");
+        const class_key_event = self.jni.findClass("android/view/KeyEvent");
 
-        const method_get_unicode_char = self.invokeJni(.GetMethodID, .{ class_key_event, "getUnicodeChar", "(I)I" });
-        const eventConstructor = self.invokeJni(.GetMethodID, .{ class_key_event, "<init>", "(II)V" });
-        const eventObj = self.invokeJni(.NewObject, .{ class_key_event, eventConstructor, eventType, keyCode });
+        const method_get_unicode_char = self.jni.invokeJni(.GetMethodID, .{ class_key_event, "getUnicodeChar", "(I)I" });
+        const eventConstructor = self.jni.invokeJni(.GetMethodID, .{ class_key_event, "<init>", "(II)V" });
+        const eventObj = self.jni.invokeJni(.NewObject, .{ class_key_event, eventConstructor, eventType, keyCode });
 
-        const unicodeKey = self.invokeJni(.CallIntMethod, .{ eventObj, method_get_unicode_char, metaState });
+        const unicodeKey = self.jni.invokeJni(.CallIntMethod, .{ eventObj, method_get_unicode_char, metaState });
 
         return @intCast(u21, unicodeKey);
     }
@@ -106,29 +121,29 @@ pub const JNI = struct {
 
         // Get android.app.NativeActivity, then get getWindow method handle, returns
         // view.Window type
-        const activityClass = self.findClass("android/app/NativeActivity");
-        const getWindow = self.invokeJni(.GetMethodID, .{ activityClass, "getWindow", "()Landroid/view/Window;" });
-        const window = self.invokeJni(.CallObjectMethod, .{ self.activity.clazz, getWindow });
+        const activityClass = self.jni.findClass("android/app/NativeActivity");
+        const getWindow = self.jni.invokeJni(.GetMethodID, .{ activityClass, "getWindow", "()Landroid/view/Window;" });
+        const window = self.jni.invokeJni(.CallObjectMethod, .{ self.activity.clazz, getWindow });
 
         // Get android.view.Window class, then get getDecorView method handle, returns
         // view.View type
-        const windowClass = self.findClass("android/view/Window");
-        const getDecorView = self.invokeJni(.GetMethodID, .{ windowClass, "getDecorView", "()Landroid/view/View;" });
-        const decorView = self.invokeJni(.CallObjectMethod, .{ window, getDecorView });
+        const windowClass = self.jni.findClass("android/view/Window");
+        const getDecorView = self.jni.invokeJni(.GetMethodID, .{ windowClass, "getDecorView", "()Landroid/view/View;" });
+        const decorView = self.jni.invokeJni(.CallObjectMethod, .{ window, getDecorView });
 
         // Get the flag values associated with systemuivisibility
-        const viewClass = self.findClass("android/view/View");
-        const flagLayoutHideNavigation = self.invokeJni(.GetStaticIntField, .{ viewClass, self.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION", "I" }) });
-        const flagLayoutFullscreen = self.invokeJni(.GetStaticIntField, .{ viewClass, self.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN", "I" }) });
-        const flagLowProfile = self.invokeJni(.GetStaticIntField, .{ viewClass, self.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_LOW_PROFILE", "I" }) });
-        const flagHideNavigation = self.invokeJni(.GetStaticIntField, .{ viewClass, self.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_HIDE_NAVIGATION", "I" }) });
-        const flagFullscreen = self.invokeJni(.GetStaticIntField, .{ viewClass, self.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_FULLSCREEN", "I" }) });
-        const flagImmersiveSticky = self.invokeJni(.GetStaticIntField, .{ viewClass, self.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_IMMERSIVE_STICKY", "I" }) });
+        const viewClass = self.jni.findClass("android/view/View");
+        const flagLayoutHideNavigation = self.jni.invokeJni(.GetStaticIntField, .{ viewClass, self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION", "I" }) });
+        const flagLayoutFullscreen = self.jni.invokeJni(.GetStaticIntField, .{ viewClass, self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN", "I" }) });
+        const flagLowProfile = self.jni.invokeJni(.GetStaticIntField, .{ viewClass, self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_LOW_PROFILE", "I" }) });
+        const flagHideNavigation = self.jni.invokeJni(.GetStaticIntField, .{ viewClass, self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_HIDE_NAVIGATION", "I" }) });
+        const flagFullscreen = self.jni.invokeJni(.GetStaticIntField, .{ viewClass, self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_FULLSCREEN", "I" }) });
+        const flagImmersiveSticky = self.jni.invokeJni(.GetStaticIntField, .{ viewClass, self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_IMMERSIVE_STICKY", "I" }) });
 
-        const setSystemUiVisibility = self.invokeJni(.GetMethodID, .{ viewClass, "setSystemUiVisibility", "(I)V" });
+        const setSystemUiVisibility = self.jni.invokeJni(.GetMethodID, .{ viewClass, "setSystemUiVisibility", "(I)V" });
 
         // Call the decorView.setSystemUiVisibility(FLAGS)
-        self.invokeJni(.CallVoidMethod, .{
+        self.jni.invokeJni(.CallVoidMethod, .{
             decorView,
             setSystemUiVisibility,
             (flagLayoutHideNavigation | flagLayoutFullscreen | flagLowProfile | flagHideNavigation | flagFullscreen | flagImmersiveSticky),
@@ -138,18 +153,18 @@ pub const JNI = struct {
         // class path search for api-versions.xml
         // https://android.googlesource.com/platform/development/+/refs/tags/android-9.0.0_r48/sdk/api-versions.xml
 
-        const layoutManagerClass = self.findClass("android/view/WindowManager$LayoutParams");
-        const flag_WinMan_Fullscreen = self.invokeJni(.GetStaticIntField, .{ layoutManagerClass, self.invokeJni(.GetStaticFieldID, .{ layoutManagerClass, "FLAG_FULLSCREEN", "I" }) });
-        const flag_WinMan_KeepScreenOn = self.invokeJni(.GetStaticIntField, .{ layoutManagerClass, self.invokeJni(.GetStaticFieldID, .{ layoutManagerClass, "FLAG_KEEP_SCREEN_ON", "I" }) });
-        const flag_WinMan_hw_acc = self.invokeJni(.GetStaticIntField, .{ layoutManagerClass, self.invokeJni(.GetStaticFieldID, .{ layoutManagerClass, "FLAG_HARDWARE_ACCELERATED", "I" }) });
+        const layoutManagerClass = self.jni.findClass("android/view/WindowManager$LayoutParams");
+        const flag_WinMan_Fullscreen = self.jni.invokeJni(.GetStaticIntField, .{ layoutManagerClass, self.jni.invokeJni(.GetStaticFieldID, .{ layoutManagerClass, "FLAG_FULLSCREEN", "I" }) });
+        const flag_WinMan_KeepScreenOn = self.jni.invokeJni(.GetStaticIntField, .{ layoutManagerClass, self.jni.invokeJni(.GetStaticFieldID, .{ layoutManagerClass, "FLAG_KEEP_SCREEN_ON", "I" }) });
+        const flag_WinMan_hw_acc = self.jni.invokeJni(.GetStaticIntField, .{ layoutManagerClass, self.jni.invokeJni(.GetStaticFieldID, .{ layoutManagerClass, "FLAG_HARDWARE_ACCELERATED", "I" }) });
         //    const int flag_WinMan_flag_not_fullscreen =
         //    env.GetStaticIntField(layoutManagerClass,
         //    (env.GetStaticFieldID(layoutManagerClass, "FLAG_FORCE_NOT_FULLSCREEN",
         //    "I") ));
         // call window.addFlags(FLAGS)
-        self.invokeJni(.CallVoidMethod, .{
+        self.jni.invokeJni(.CallVoidMethod, .{
             window,
-            self.invokeJni(.GetMethodID, .{ windowClass, "addFlags", "(I)V" }),
+            self.jni.invokeJni(.GetMethodID, .{ windowClass, "addFlags", "(I)V" }),
             (flag_WinMan_Fullscreen | flag_WinMan_KeepScreenOn | flag_WinMan_hw_acc),
         });
     }
@@ -160,35 +175,35 @@ pub const JNI = struct {
         var lFlags: android.jint = 0;
 
         // Retrieves Context.INPUT_METHOD_SERVICE.
-        const ClassContext = self.findClass("android/content/Context");
-        const FieldINPUT_METHOD_SERVICE = self.invokeJni(.GetStaticFieldID, .{ ClassContext, "INPUT_METHOD_SERVICE", "Ljava/lang/String;" });
-        const INPUT_METHOD_SERVICE = self.invokeJni(.GetStaticObjectField, .{ ClassContext, FieldINPUT_METHOD_SERVICE });
+        const ClassContext = self.jni.findClass("android/content/Context");
+        const FieldINPUT_METHOD_SERVICE = self.jni.invokeJni(.GetStaticFieldID, .{ ClassContext, "INPUT_METHOD_SERVICE", "Ljava/lang/String;" });
+        const INPUT_METHOD_SERVICE = self.jni.invokeJni(.GetStaticObjectField, .{ ClassContext, FieldINPUT_METHOD_SERVICE });
 
         // Runs getSystemService(Context.INPUT_METHOD_SERVICE).
-        const ClassInputMethodManager = self.findClass("android/view/inputmethod/InputMethodManager");
-        const MethodGetSystemService = self.invokeJni(.GetMethodID, .{ self.activity_class, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;" });
-        const lInputMethodManager = self.invokeJni(.CallObjectMethod, .{ self.activity.clazz, MethodGetSystemService, INPUT_METHOD_SERVICE });
+        const ClassInputMethodManager = self.jni.findClass("android/view/inputmethod/InputMethodManager");
+        const MethodGetSystemService = self.jni.invokeJni(.GetMethodID, .{ self.activity_class, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;" });
+        const lInputMethodManager = self.jni.invokeJni(.CallObjectMethod, .{ self.activity.clazz, MethodGetSystemService, INPUT_METHOD_SERVICE });
 
         // Runs getWindow().getDecorView().
-        const MethodGetWindow = self.invokeJni(.GetMethodID, .{ self.activity_class, "getWindow", "()Landroid/view/Window;" });
-        const lWindow = self.invokeJni(.CallObjectMethod, .{ self.activity.clazz, MethodGetWindow });
-        const ClassWindow = self.findClass("android/view/Window");
-        const MethodGetDecorView = self.invokeJni(.GetMethodID, .{ ClassWindow, "getDecorView", "()Landroid/view/View;" });
-        const lDecorView = self.invokeJni(.CallObjectMethod, .{ lWindow, MethodGetDecorView });
+        const MethodGetWindow = self.jni.invokeJni(.GetMethodID, .{ self.activity_class, "getWindow", "()Landroid/view/Window;" });
+        const lWindow = self.jni.invokeJni(.CallObjectMethod, .{ self.activity.clazz, MethodGetWindow });
+        const ClassWindow = self.jni.findClass("android/view/Window");
+        const MethodGetDecorView = self.jni.invokeJni(.GetMethodID, .{ ClassWindow, "getDecorView", "()Landroid/view/View;" });
+        const lDecorView = self.jni.invokeJni(.CallObjectMethod, .{ lWindow, MethodGetDecorView });
 
         if (show) {
             // Runs lInputMethodManager.showSoftInput(...).
-            const MethodShowSoftInput = self.invokeJni(.GetMethodID, .{ ClassInputMethodManager, "showSoftInput", "(Landroid/view/View;I)Z" });
-            return 0 != self.invokeJni(.CallBooleanMethod, .{ lInputMethodManager, MethodShowSoftInput, lDecorView, lFlags });
+            const MethodShowSoftInput = self.jni.invokeJni(.GetMethodID, .{ ClassInputMethodManager, "showSoftInput", "(Landroid/view/View;I)Z" });
+            return 0 != self.jni.invokeJni(.CallBooleanMethod, .{ lInputMethodManager, MethodShowSoftInput, lDecorView, lFlags });
         } else {
             // Runs lWindow.getViewToken()
-            const ClassView = self.findClass("android/view/View");
-            const MethodGetWindowToken = self.invokeJni(.GetMethodID, .{ ClassView, "getWindowToken", "()Landroid/os/IBinder;" });
-            const lBinder = self.invokeJni(.CallObjectMethod, .{ lDecorView, MethodGetWindowToken });
+            const ClassView = self.jni.findClass("android/view/View");
+            const MethodGetWindowToken = self.jni.invokeJni(.GetMethodID, .{ ClassView, "getWindowToken", "()Landroid/os/IBinder;" });
+            const lBinder = self.jni.invokeJni(.CallObjectMethod, .{ lDecorView, MethodGetWindowToken });
 
             // lInputMethodManager.hideSoftInput(...).
-            const MethodHideSoftInput = self.invokeJni(.GetMethodID, .{ ClassInputMethodManager, "hideSoftInputFromWindow", "(Landroid/os/IBinder;I)Z" });
-            return 0 != self.invokeJni(.CallBooleanMethod, .{ lInputMethodManager, MethodHideSoftInput, lBinder, lFlags });
+            const MethodHideSoftInput = self.jni.invokeJni(.GetMethodID, .{ ClassInputMethodManager, "hideSoftInputFromWindow", "(Landroid/os/IBinder;I)Z" });
+            return 0 != self.jni.invokeJni(.CallBooleanMethod, .{ lInputMethodManager, MethodHideSoftInput, lBinder, lFlags });
         }
     }
 
@@ -197,10 +212,10 @@ pub const JNI = struct {
     /// nonRoot: If false then this only works if the activity is the root of a task; if true it will work for any activity in a task.
     /// returns: If the task was moved (or it was already at the back) true is returned, else false.
     pub fn AndroidSendToBack(self: *Self, nonRoot: bool) bool {
-        const ClassActivity = self.findClass("android/app/Activity");
-        const MethodmoveTaskToBack = self.invokeJni(.GetMethodID, .{ ClassActivity, "moveTaskToBack", "(Z)Z" });
+        const ClassActivity = self.jni.findClass("android/app/Activity");
+        const MethodmoveTaskToBack = self.jni.invokeJni(.GetMethodID, .{ ClassActivity, "moveTaskToBack", "(Z)Z" });
 
-        return 0 != self.invokeJni(.CallBooleanMethod, .{ self.activity.clazz, MethodmoveTaskToBack, if (nonRoot) @as(c_int, 1) else 0 });
+        return 0 != self.jni.invokeJni(.CallBooleanMethod, .{ self.activity.clazz, MethodmoveTaskToBack, if (nonRoot) @as(c_int, 1) else 0 });
     }
 
     pub fn AndroidHasPermissions(self: *Self, perm_name: [:0]const u8) bool {
@@ -212,17 +227,17 @@ pub const JNI = struct {
             return false;
         }
 
-        const ls_PERM = self.invokeJni(.NewStringUTF, .{perm_name});
+        const ls_PERM = self.jni.invokeJni(.NewStringUTF, .{perm_name});
 
         const PERMISSION_GRANTED = blk: {
-            var ClassPackageManager = self.findClass("android/content/pm/PackageManager");
-            var lid_PERMISSION_GRANTED = self.invokeJni(.GetStaticFieldID, .{ ClassPackageManager, "PERMISSION_GRANTED", "I" });
-            break :blk self.invokeJni(.GetStaticIntField, .{ ClassPackageManager, lid_PERMISSION_GRANTED });
+            var ClassPackageManager = self.jni.findClass("android/content/pm/PackageManager");
+            var lid_PERMISSION_GRANTED = self.jni.invokeJni(.GetStaticFieldID, .{ ClassPackageManager, "PERMISSION_GRANTED", "I" });
+            break :blk self.jni.invokeJni(.GetStaticIntField, .{ ClassPackageManager, lid_PERMISSION_GRANTED });
         };
 
-        const ClassContext = self.findClass("android/content/Context");
-        const MethodcheckSelfPermission = self.invokeJni(.GetMethodID, .{ ClassContext, "checkSelfPermission", "(Ljava/lang/String;)I" });
-        const int_result = self.invokeJni(.CallIntMethod, .{ self.activity.clazz, MethodcheckSelfPermission, ls_PERM });
+        const ClassContext = self.jni.findClass("android/content/Context");
+        const MethodcheckSelfPermission = self.jni.invokeJni(.GetMethodID, .{ ClassContext, "checkSelfPermission", "(Ljava/lang/String;)I" });
+        const int_result = self.jni.invokeJni(.CallIntMethod, .{ self.activity.clazz, MethodcheckSelfPermission, ls_PERM });
         return (int_result == PERMISSION_GRANTED);
     }
 
@@ -235,33 +250,33 @@ pub const JNI = struct {
             return;
         }
 
-        const perm_array = self.invokeJni(.NewObjectArray, .{
+        const perm_array = self.jni.invokeJni(.NewObjectArray, .{
             1,
-            self.findClass("java/lang/String"),
-            self.invokeJni(.NewStringUTF, .{perm_name}),
+            self.jni.findClass("java/lang/String"),
+            self.jni.invokeJni(.NewStringUTF, .{perm_name}),
         });
 
-        const MethodrequestPermissions = self.invokeJni(.GetMethodID, .{ self.activity_class, "requestPermissions", "([Ljava/lang/String;I)V" });
+        const MethodrequestPermissions = self.jni.invokeJni(.GetMethodID, .{ self.activity_class, "requestPermissions", "([Ljava/lang/String;I)V" });
 
         // Last arg (0) is just for the callback (that I do not use)
-        self.invokeJni(.CallVoidMethod, .{ self.activity.clazz, MethodrequestPermissions, perm_array, @as(c_int, 0) });
+        self.jni.invokeJni(.CallVoidMethod, .{ self.activity.clazz, MethodrequestPermissions, perm_array, @as(c_int, 0) });
     }
 
     pub fn getFilesDir(self: *Self, allocator: std.mem.Allocator) ![:0]const u8 {
-        const getFilesDirMethod = self.invokeJni(.GetMethodID, .{ self.activity_class, "getFilesDir", "()Ljava/io/File;" });
+        const getFilesDirMethod = self.jni.invokeJni(.GetMethodID, .{ self.activity_class, "getFilesDir", "()Ljava/io/File;" });
 
         const files_dir = self.env.*.CallObjectMethod(self.env, self.activity.clazz, getFilesDirMethod);
 
-        const fileClass = self.findClass("java/io/File");
+        const fileClass = self.jni.findClass("java/io/File");
 
-        const getPathMethod = self.invokeJni(.GetMethodID, .{ fileClass, "getPath", "()Ljava/lang/String;" });
+        const getPathMethod = self.jni.invokeJni(.GetMethodID, .{ fileClass, "getPath", "()Ljava/lang/String;" });
 
         const path_string = self.env.*.CallObjectMethod(self.env, files_dir, getPathMethod);
 
-        const utf8_or_null = self.invokeJni(.GetStringUTFChars, .{ path_string, null });
+        const utf8_or_null = self.jni.invokeJni(.GetStringUTFChars, .{ path_string, null });
 
         if (utf8_or_null) |utf8_ptr| {
-            defer self.invokeJni(.ReleaseStringUTFChars, .{ path_string, utf8_ptr });
+            defer self.jni.invokeJni(.ReleaseStringUTFChars, .{ path_string, utf8_ptr });
 
             const utf8 = std.mem.sliceTo(utf8_ptr, 0);
 

--- a/src/jni.zig
+++ b/src/jni.zig
@@ -8,16 +8,13 @@ const android = @import("android-support.zig");
 /// const jni = @ptrCast(*JNI, jni_env);
 /// ```
 pub const JNI = opaque {
-    pub fn findClass(jni: *JNI, class: [:0]const u8) android.jclass {
-        return jni.invokeJni(.FindClass, .{class.ptr});
-    }
-
+    // Underlying implementation
     fn JniReturnType(comptime function: @TypeOf(.literal)) type {
         @setEvalBranchQuota(10_000);
         return @typeInfo(@typeInfo(std.meta.fieldInfo(android.JNINativeInterface, function).type).Pointer.child).Fn.return_type.?;
     }
 
-    pub inline fn invokeJni(jni: *JNI, comptime function: @TypeOf(.literal), args: anytype) JniReturnType(function) {
+    pub inline fn invokeJniNoException(jni: *JNI, comptime function: @TypeOf(.literal), args: anytype) JniReturnType(function) {
         const env = @ptrCast(*android.JNIEnv, @alignCast(@alignOf(*android.JNIEnv), jni));
         return @call(
             .auto,
@@ -26,31 +23,55 @@ pub const JNI = opaque {
         );
     }
 
-    pub fn getClassNameString(jni: *JNI, object: android.jobject) String {
-        const object_class = jni.invokeJni(.GetObjectClass, .{object});
-        const ClassClass = jni.findClass("java/lang/Class");
-        const getName = jni.invokeJni(.GetMethodID, .{ ClassClass, "getName", "()Ljava/lang/String;" });
-        const name = jni.invokeJni(.CallObjectMethod, .{ object_class, getName });
+    /// Possible JNI Errors
+    const Error = error{
+        ExceptionThrown,
+        ClassNotDefined,
+    };
+
+    pub inline fn invokeJni(jni: *JNI, comptime function: @TypeOf(.literal), args: anytype) Error!JniReturnType(function) {
+        const value = jni.invokeJniNoException(function, args);
+        if (jni.invokeJniNoException(.ExceptionCheck, .{}) == android.JNI_TRUE) {
+            log.err("Encountered exception while calling: {s} {any}", .{ @tagName(function), args });
+            return Error.ExceptionThrown;
+        }
+        return value;
+    }
+
+    // Convenience functions
+
+    pub fn findClass(jni: *JNI, class: [:0]const u8) Error!android.jclass {
+        return jni.invokeJni(.FindClass, .{class.ptr}) catch {
+            log.err("Class Not Found: {s}", .{class});
+            return Error.ClassNotDefined;
+        };
+    }
+
+    pub fn getClassNameString(jni: *JNI, object: android.jobject) Error!String {
+        const object_class = try jni.invokeJni(.GetObjectClass, .{object});
+        const ClassClass = try jni.findClass("java/lang/Class");
+        const getName = try jni.invokeJni(.GetMethodID, .{ ClassClass, "getName", "()Ljava/lang/String;" });
+        const name = try jni.invokeJni(.CallObjectMethod, .{ object_class, getName });
         return String.init(jni, name);
     }
 
     pub fn printToString(jni: *JNI, object: android.jobject) void {
-        const string = String.init(jni, jni.callObjectMethod(object, "toString", "()Ljava/lang/String;", .{}));
+        const string = try String.init(jni, try jni.callObjectMethod(object, "toString", "()Ljava/lang/String;", .{}));
         defer string.deinit(jni);
-        std.log.info("{any}: {}", .{ object, std.unicode.fmtUtf16le(string.slice) });
+        log.info("{any}: {}", .{ object, std.unicode.fmtUtf16le(string.slice) });
     }
 
-    pub fn newString(jni: *JNI, string: [*:0]const u8) android.jstring {
+    pub fn newString(jni: *JNI, string: [*:0]const u8) Error!android.jstring {
         return jni.invokeJni(.NewStringUTF, .{string});
     }
 
-    pub fn getLongField(jni: *JNI, object: android.jobject, field_id: android.jfieldID) android.jlong {
+    pub fn getLongField(jni: *JNI, object: android.jobject, field_id: android.jfieldID) !android.jlong {
         return jni.invokeJni(.GetLongField, .{ object, field_id });
     }
 
-    pub fn callObjectMethod(jni: *JNI, object: android.jobject, name: [:0]const u8, signature: [:0]const u8, args: anytype) JniReturnType(.CallObjectMethod) {
-        const object_class = jni.invokeJni(.GetObjectClass, .{object});
-        const method_id = jni.invokeJni(.GetMethodID, .{ object_class, name, signature });
+    pub fn callObjectMethod(jni: *JNI, object: android.jobject, name: [:0]const u8, signature: [:0]const u8, args: anytype) Error!JniReturnType(.CallObjectMethod) {
+        const object_class = try jni.invokeJni(.GetObjectClass, .{object});
+        const method_id = try jni.invokeJni(.GetMethodID, .{ object_class, name, signature });
         return jni.invokeJni(.CallObjectMethod, .{ object, method_id } ++ args);
     }
 
@@ -58,9 +79,9 @@ pub const JNI = opaque {
         jstring: android.jstring,
         slice: []const u16,
 
-        pub fn init(jni: *JNI, string: android.jstring) String {
-            const len = jni.invokeJni(.GetStringLength, .{string});
-            const ptr = jni.invokeJni(.GetStringChars, .{ string, null });
+        pub fn init(jni: *JNI, string: android.jstring) Error!String {
+            const len = try jni.invokeJni(.GetStringLength, .{string});
+            const ptr = try jni.invokeJni(.GetStringChars, .{ string, null });
             const slice = ptr[0..@intCast(usize, len)];
             return String{
                 .jstring = string,
@@ -69,238 +90,7 @@ pub const JNI = opaque {
         }
 
         pub fn deinit(string: String, jni: *JNI) void {
-            jni.invokeJni(.ReleaseStringChars, .{ string.jstring, string.slice.ptr });
+            jni.invokeJniNoException(.ReleaseStringChars, .{ string.jstring, string.slice.ptr });
         }
     };
-};
-
-pub const NativeActivity = struct {
-    const Self = @This();
-
-    activity: *android.ANativeActivity,
-    jni: *JNI,
-    activity_class: android.jclass,
-
-    pub fn init(activity: *android.ANativeActivity) Self {
-        var env: *android.JNIEnv = undefined;
-        _ = activity.vm.*.AttachCurrentThread(activity.vm, &env, null);
-        return fromJniEnv(activity, env);
-    }
-
-    /// Get the JNIEnv associated with the current thread.
-    pub fn get(activity: *android.ANativeActivity) Self {
-        var env: *android.JNIEnv = undefined;
-        _ = activity.vm.*.GetEnv(activity.vm, @ptrCast(*?*anyopaque, &env), android.JNI_VERSION_1_6);
-        return fromJniEnv(activity, env);
-    }
-
-    fn fromJniEnv(activity: *android.ANativeActivity, env: *android.JNIEnv) Self {
-        var activityClass = env.*.FindClass(env, "android/app/NativeActivity");
-
-        return Self{
-            .activity = activity,
-            .jni = @ptrCast(*JNI, env),
-            .activity_class = activityClass,
-        };
-    }
-
-    pub fn deinit(self: *Self) void {
-        _ = self.activity.vm.*.DetachCurrentThread(self.activity.vm);
-        self.* = undefined;
-    }
-
-    pub fn AndroidGetUnicodeChar(self: *Self, keyCode: c_int, metaState: c_int) u21 {
-        // https://stackoverflow.com/questions/21124051/receive-complete-android-unicode-input-in-c-c/43871301
-        const eventType = android.AKEY_EVENT_ACTION_DOWN;
-
-        const class_key_event = self.jni.findClass("android/view/KeyEvent");
-
-        const method_get_unicode_char = self.jni.invokeJni(.GetMethodID, .{ class_key_event, "getUnicodeChar", "(I)I" });
-        const eventConstructor = self.jni.invokeJni(.GetMethodID, .{ class_key_event, "<init>", "(II)V" });
-        const eventObj = self.jni.invokeJni(.NewObject, .{ class_key_event, eventConstructor, eventType, keyCode });
-
-        const unicodeKey = self.jni.invokeJni(.CallIntMethod, .{ eventObj, method_get_unicode_char, metaState });
-
-        return @intCast(u21, unicodeKey);
-    }
-
-    pub fn AndroidMakeFullscreen(self: *Self) void {
-        // Partially based on
-        // https://stackoverflow.com/questions/47507714/how-do-i-enable-full-screen-immersive-mode-for-a-native-activity-ndk-app
-
-        // Get android.app.NativeActivity, then get getWindow method handle, returns
-        // view.Window type
-        const activityClass = self.jni.findClass("android/app/NativeActivity");
-        const getWindow = self.jni.invokeJni(.GetMethodID, .{ activityClass, "getWindow", "()Landroid/view/Window;" });
-        const window = self.jni.invokeJni(.CallObjectMethod, .{ self.activity.clazz, getWindow });
-
-        // Get android.view.Window class, then get getDecorView method handle, returns
-        // view.View type
-        const windowClass = self.jni.findClass("android/view/Window");
-        const getDecorView = self.jni.invokeJni(.GetMethodID, .{ windowClass, "getDecorView", "()Landroid/view/View;" });
-        const decorView = self.jni.invokeJni(.CallObjectMethod, .{ window, getDecorView });
-
-        // Get the flag values associated with systemuivisibility
-        const viewClass = self.jni.findClass("android/view/View");
-        const flagLayoutHideNavigation = self.jni.invokeJni(.GetStaticIntField, .{ viewClass, self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION", "I" }) });
-        const flagLayoutFullscreen = self.jni.invokeJni(.GetStaticIntField, .{ viewClass, self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN", "I" }) });
-        const flagLowProfile = self.jni.invokeJni(.GetStaticIntField, .{ viewClass, self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_LOW_PROFILE", "I" }) });
-        const flagHideNavigation = self.jni.invokeJni(.GetStaticIntField, .{ viewClass, self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_HIDE_NAVIGATION", "I" }) });
-        const flagFullscreen = self.jni.invokeJni(.GetStaticIntField, .{ viewClass, self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_FULLSCREEN", "I" }) });
-        const flagImmersiveSticky = self.jni.invokeJni(.GetStaticIntField, .{ viewClass, self.jni.invokeJni(.GetStaticFieldID, .{ viewClass, "SYSTEM_UI_FLAG_IMMERSIVE_STICKY", "I" }) });
-
-        const setSystemUiVisibility = self.jni.invokeJni(.GetMethodID, .{ viewClass, "setSystemUiVisibility", "(I)V" });
-
-        // Call the decorView.setSystemUiVisibility(FLAGS)
-        self.jni.invokeJni(.CallVoidMethod, .{
-            decorView,
-            setSystemUiVisibility,
-            (flagLayoutHideNavigation | flagLayoutFullscreen | flagLowProfile | flagHideNavigation | flagFullscreen | flagImmersiveSticky),
-        });
-
-        // now set some more flags associated with layoutmanager -- note the $ in the
-        // class path search for api-versions.xml
-        // https://android.googlesource.com/platform/development/+/refs/tags/android-9.0.0_r48/sdk/api-versions.xml
-
-        const layoutManagerClass = self.jni.findClass("android/view/WindowManager$LayoutParams");
-        const flag_WinMan_Fullscreen = self.jni.invokeJni(.GetStaticIntField, .{ layoutManagerClass, self.jni.invokeJni(.GetStaticFieldID, .{ layoutManagerClass, "FLAG_FULLSCREEN", "I" }) });
-        const flag_WinMan_KeepScreenOn = self.jni.invokeJni(.GetStaticIntField, .{ layoutManagerClass, self.jni.invokeJni(.GetStaticFieldID, .{ layoutManagerClass, "FLAG_KEEP_SCREEN_ON", "I" }) });
-        const flag_WinMan_hw_acc = self.jni.invokeJni(.GetStaticIntField, .{ layoutManagerClass, self.jni.invokeJni(.GetStaticFieldID, .{ layoutManagerClass, "FLAG_HARDWARE_ACCELERATED", "I" }) });
-        //    const int flag_WinMan_flag_not_fullscreen =
-        //    env.GetStaticIntField(layoutManagerClass,
-        //    (env.GetStaticFieldID(layoutManagerClass, "FLAG_FORCE_NOT_FULLSCREEN",
-        //    "I") ));
-        // call window.addFlags(FLAGS)
-        self.jni.invokeJni(.CallVoidMethod, .{
-            window,
-            self.jni.invokeJni(.GetMethodID, .{ windowClass, "addFlags", "(I)V" }),
-            (flag_WinMan_Fullscreen | flag_WinMan_KeepScreenOn | flag_WinMan_hw_acc),
-        });
-    }
-
-    pub fn AndroidDisplayKeyboard(self: *Self, show: bool) bool {
-        // Based on
-        // https://stackoverflow.com/questions/5864790/how-to-show-the-soft-keyboard-on-native-activity
-        var lFlags: android.jint = 0;
-
-        // Retrieves Context.INPUT_METHOD_SERVICE.
-        const ClassContext = self.jni.findClass("android/content/Context");
-        const FieldINPUT_METHOD_SERVICE = self.jni.invokeJni(.GetStaticFieldID, .{ ClassContext, "INPUT_METHOD_SERVICE", "Ljava/lang/String;" });
-        const INPUT_METHOD_SERVICE = self.jni.invokeJni(.GetStaticObjectField, .{ ClassContext, FieldINPUT_METHOD_SERVICE });
-
-        // Runs getSystemService(Context.INPUT_METHOD_SERVICE).
-        const ClassInputMethodManager = self.jni.findClass("android/view/inputmethod/InputMethodManager");
-        const MethodGetSystemService = self.jni.invokeJni(.GetMethodID, .{ self.activity_class, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;" });
-        const lInputMethodManager = self.jni.invokeJni(.CallObjectMethod, .{ self.activity.clazz, MethodGetSystemService, INPUT_METHOD_SERVICE });
-
-        // Runs getWindow().getDecorView().
-        const MethodGetWindow = self.jni.invokeJni(.GetMethodID, .{ self.activity_class, "getWindow", "()Landroid/view/Window;" });
-        const lWindow = self.jni.invokeJni(.CallObjectMethod, .{ self.activity.clazz, MethodGetWindow });
-        const ClassWindow = self.jni.findClass("android/view/Window");
-        const MethodGetDecorView = self.jni.invokeJni(.GetMethodID, .{ ClassWindow, "getDecorView", "()Landroid/view/View;" });
-        const lDecorView = self.jni.invokeJni(.CallObjectMethod, .{ lWindow, MethodGetDecorView });
-
-        if (show) {
-            // Runs lInputMethodManager.showSoftInput(...).
-            const MethodShowSoftInput = self.jni.invokeJni(.GetMethodID, .{ ClassInputMethodManager, "showSoftInput", "(Landroid/view/View;I)Z" });
-            return 0 != self.jni.invokeJni(.CallBooleanMethod, .{ lInputMethodManager, MethodShowSoftInput, lDecorView, lFlags });
-        } else {
-            // Runs lWindow.getViewToken()
-            const ClassView = self.jni.findClass("android/view/View");
-            const MethodGetWindowToken = self.jni.invokeJni(.GetMethodID, .{ ClassView, "getWindowToken", "()Landroid/os/IBinder;" });
-            const lBinder = self.jni.invokeJni(.CallObjectMethod, .{ lDecorView, MethodGetWindowToken });
-
-            // lInputMethodManager.hideSoftInput(...).
-            const MethodHideSoftInput = self.jni.invokeJni(.GetMethodID, .{ ClassInputMethodManager, "hideSoftInputFromWindow", "(Landroid/os/IBinder;I)Z" });
-            return 0 != self.jni.invokeJni(.CallBooleanMethod, .{ lInputMethodManager, MethodHideSoftInput, lBinder, lFlags });
-        }
-    }
-
-    /// Move the task containing this activity to the back of the activity stack.
-    /// The activity's order within the task is unchanged.
-    /// nonRoot: If false then this only works if the activity is the root of a task; if true it will work for any activity in a task.
-    /// returns: If the task was moved (or it was already at the back) true is returned, else false.
-    pub fn AndroidSendToBack(self: *Self, nonRoot: bool) bool {
-        const ClassActivity = self.jni.findClass("android/app/Activity");
-        const MethodmoveTaskToBack = self.jni.invokeJni(.GetMethodID, .{ ClassActivity, "moveTaskToBack", "(Z)Z" });
-
-        return 0 != self.jni.invokeJni(.CallBooleanMethod, .{ self.activity.clazz, MethodmoveTaskToBack, if (nonRoot) @as(c_int, 1) else 0 });
-    }
-
-    pub fn AndroidHasPermissions(self: *Self, perm_name: [:0]const u8) bool {
-        if (android.sdk_version < 23) {
-            log.err(
-                "Android SDK version {} does not support AndroidRequestAppPermissions\n",
-                .{android.sdk_version},
-            );
-            return false;
-        }
-
-        const ls_PERM = self.jni.invokeJni(.NewStringUTF, .{perm_name});
-
-        const PERMISSION_GRANTED = blk: {
-            var ClassPackageManager = self.jni.findClass("android/content/pm/PackageManager");
-            var lid_PERMISSION_GRANTED = self.jni.invokeJni(.GetStaticFieldID, .{ ClassPackageManager, "PERMISSION_GRANTED", "I" });
-            break :blk self.jni.invokeJni(.GetStaticIntField, .{ ClassPackageManager, lid_PERMISSION_GRANTED });
-        };
-
-        const ClassContext = self.jni.findClass("android/content/Context");
-        const MethodcheckSelfPermission = self.jni.invokeJni(.GetMethodID, .{ ClassContext, "checkSelfPermission", "(Ljava/lang/String;)I" });
-        const int_result = self.jni.invokeJni(.CallIntMethod, .{ self.activity.clazz, MethodcheckSelfPermission, ls_PERM });
-        return (int_result == PERMISSION_GRANTED);
-    }
-
-    pub fn AndroidRequestAppPermissions(self: *Self, perm_name: [:0]const u8) void {
-        if (android.sdk_version < 23) {
-            log.err(
-                "Android SDK version {} does not support AndroidRequestAppPermissions\n",
-                .{android.sdk_version},
-            );
-            return;
-        }
-
-        const perm_array = self.jni.invokeJni(.NewObjectArray, .{
-            1,
-            self.jni.findClass("java/lang/String"),
-            self.jni.invokeJni(.NewStringUTF, .{perm_name}),
-        });
-
-        const MethodrequestPermissions = self.jni.invokeJni(.GetMethodID, .{ self.activity_class, "requestPermissions", "([Ljava/lang/String;I)V" });
-
-        // Last arg (0) is just for the callback (that I do not use)
-        self.jni.invokeJni(.CallVoidMethod, .{ self.activity.clazz, MethodrequestPermissions, perm_array, @as(c_int, 0) });
-    }
-
-    pub fn getFilesDir(self: *Self, allocator: std.mem.Allocator) ![:0]const u8 {
-        const getFilesDirMethod = self.jni.invokeJni(.GetMethodID, .{ self.activity_class, "getFilesDir", "()Ljava/io/File;" });
-
-        const files_dir = self.jni.*.CallObjectMethod(self.jni, self.activity.clazz, getFilesDirMethod);
-
-        const fileClass = self.jni.findClass("java/io/File");
-
-        const getPathMethod = self.jni.invokeJni(.GetMethodID, .{ fileClass, "getPath", "()Ljava/lang/String;" });
-
-        const path_string = self.jni.*.CallObjectMethod(self.jni, files_dir, getPathMethod);
-
-        const utf8_or_null = self.jni.invokeJni(.GetStringUTFChars, .{ path_string, null });
-
-        if (utf8_or_null) |utf8_ptr| {
-            defer self.jni.invokeJni(.ReleaseStringUTFChars, .{ path_string, utf8_ptr });
-
-            const utf8 = std.mem.sliceTo(utf8_ptr, 0);
-
-            return try allocator.dupeZ(u8, utf8);
-        } else {
-            return error.OutOfMemory;
-        }
-    }
-
-    comptime {
-        _ = AndroidGetUnicodeChar;
-        _ = AndroidMakeFullscreen;
-        _ = AndroidDisplayKeyboard;
-        _ = AndroidSendToBack;
-        _ = AndroidHasPermissions;
-        _ = AndroidRequestAppPermissions;
-    }
 };

--- a/src/native-invocation-handler.zig
+++ b/src/native-invocation-handler.zig
@@ -55,7 +55,8 @@ const InvocationHandler = struct {
     function: InvokeFn,
 
     /// Called by java class NativeInvocationHandler
-    pub fn invoke0(jni_env: *android.JNIEnv, this: android.jobject, method: android.jobject, args: android.jobjectArray) android.jobject {
+    pub fn invoke0(jni_env: *android.JNIEnv, this: android.jobject, proxy: android.jobject, method: android.jobject, args: android.jobjectArray) android.jobject {
+        _ = proxy; // This is the proxy object. Calling anything on it will cause invoke to be called. If this isn't explicitly handled, it will recurse infinitely
         const jni = android.jni.JNI.init(jni_env);
         const Class = jni.invokeJni(.GetObjectClass, .{this});
         const ptrField = jni.invokeJni(.GetFieldID, .{ Class, "ptr", "J" });

--- a/src/native-invocation-handler.zig
+++ b/src/native-invocation-handler.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const android = @import("android-support.zig");
+const Self = @This();
+
+class: android.jobject,
+initFn: android.jmethodID,
+
+pub fn init(jni: android.JNI, class: android.jobject) Self {
+    // const native_invocation_handler_buffer = @embedFile("NativeInvocationHandler.dex");
+    // TODO: define class is not implemented on android
+    // const NativeInvocationHandler = jni.invokeJni(.DefineClass, .{ "NativeInvocationHandler", class_loader, @ptrCast([*]const i8, &native_invocation_handler_buffer), native_invocation_handler_buffer.len });
+    // const NativeInvocationHandler = jni.findClass("NativeInvocationHandler");
+    // const NativeInvocationHandler = jni.findClass("net/random_projects/zig_android_template/NativeInvocationHandler");
+    return Self{
+        .class = class,
+        .initFn = jni.invokeJni(.GetMethodID, .{ class, "<init>", "(J)V" }),
+    };
+}
+
+pub fn createAlloc(self: Self, jni: android.JNI, alloc: std.mem.Allocator, pointer: ?*anyopaque, function: InvokeFn) !*InvocationHandler {
+    // Create a InvocationHandler struct
+    var handler = try alloc.create(InvocationHandler);
+    errdefer alloc.destroy(handler);
+    handler.* = .{
+        .pointer = pointer,
+        .function = function,
+    };
+
+    const handler_value = @ptrToInt(handler);
+    std.debug.assert(handler_value <= 0x7fffffffffffffff);
+
+    // Call handler constructor
+    const result = jni.invokeJni(.NewObject, .{ self.class, self.initFn, handler_value }) orelse return error.InvocationHandlerInitError;
+    // if (result != null) return error.InvocationHandlerInitError;
+    _ = result;
+
+    return handler;
+}
+
+/// Function signature for invoke functions
+pub const InvokeFn = *const fn (?*anyopaque, android.JNI, android.jobject, android.jobjectArray) void;
+
+/// InvocationHandler Technique found here https://groups.google.com/g/android-ndk/c/SRgy93Un8vM
+const InvocationHandler = struct {
+    pointer: ?*anyopaque,
+    function: InvokeFn,
+
+    /// Called by java class NativeInvocationHandler
+    pub fn invoke0(jni: *android.JNIEnv, this: android.jobject, method: android.jobject, args: android.jobjectArray) android.jobject {
+        const Class = jni.invokeJni(.GetObjectClass, .{this});
+        const ptrField = jni.invokeJni(.GetFieldID, .{ Class, "ptr", "J" });
+        const jptr = jni.GetLongField(this, ptrField);
+        const h = @intToPtr(*InvocationHandler, jptr);
+        return h.function(h.pointer, jni, method, args);
+    }
+};

--- a/src/native-invocation-handler.zig
+++ b/src/native-invocation-handler.zig
@@ -11,6 +11,14 @@ pub fn init(jni: android.JNI, class: android.jobject) Self {
     // const NativeInvocationHandler = jni.invokeJni(.DefineClass, .{ "NativeInvocationHandler", class_loader, @ptrCast([*]const i8, &native_invocation_handler_buffer), native_invocation_handler_buffer.len });
     // const NativeInvocationHandler = jni.findClass("NativeInvocationHandler");
     // const NativeInvocationHandler = jni.findClass("net/random_projects/zig_android_template/NativeInvocationHandler");
+    const methods = [_]android.JNINativeMethod{
+        .{
+            .name = "invoke0",
+            .signature = "(Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;",
+            .fnPtr = InvocationHandler.invoke0,
+        },
+    };
+    _ = jni.invokeJni(.RegisterNatives, .{ class, &methods, methods.len });
     return Self{
         .class = class,
         .initFn = jni.invokeJni(.GetMethodID, .{ class, "<init>", "(J)V" }),
@@ -39,7 +47,7 @@ pub fn createAlloc(self: Self, jni: android.JNI, alloc: std.mem.Allocator, point
 }
 
 /// Function signature for invoke functions
-pub const InvokeFn = *const fn (?*anyopaque, android.JNI, android.jobject, android.jobjectArray) void;
+pub const InvokeFn = *const fn (?*anyopaque, *android.JNIEnv, android.jobject, android.jobjectArray) android.jobject;
 
 /// InvocationHandler Technique found here https://groups.google.com/g/android-ndk/c/SRgy93Un8vM
 const InvocationHandler = struct {
@@ -47,11 +55,14 @@ const InvocationHandler = struct {
     function: InvokeFn,
 
     /// Called by java class NativeInvocationHandler
-    pub fn invoke0(jni: *android.JNIEnv, this: android.jobject, method: android.jobject, args: android.jobjectArray) android.jobject {
-        const Class = jni.invokeJni(.GetObjectClass, .{this});
-        const ptrField = jni.invokeJni(.GetFieldID, .{ Class, "ptr", "J" });
-        const jptr = jni.GetLongField(this, ptrField);
-        const h = @intToPtr(*InvocationHandler, jptr);
-        return h.function(h.pointer, jni, method, args);
+    pub fn invoke0(jni_env: *android.JNIEnv, this: android.jobject, method: android.jobject, args: android.jobjectArray) android.jobject {
+        const Class = @call(.auto, @field(jni_env.*, "GetObjectClass"), .{ jni_env, this });
+        // const Class = jni.invokeJni(.GetObjectClass, .{this});
+        const ptrField = @call(.auto, @field(jni_env.*, "GetFieldID"), .{ jni_env, Class, "ptr", "J" });
+        // const ptrField = jni.invokeJni(.GetFieldID, .{ Class, "ptr", "J" });
+        const jptr = @call(.auto, @field(jni_env.*, "GetLongField"), .{ jni_env, this, ptrField });
+        // const jptr = jni.GetLongField(this, ptrField);
+        const h = @intToPtr(*InvocationHandler, @intCast(usize, jptr));
+        return h.function(h.pointer, jni_env, method, args);
     }
 };

--- a/src/native-invocation-handler.zig
+++ b/src/native-invocation-handler.zig
@@ -6,11 +6,6 @@ class: android.jobject,
 initFn: android.jmethodID,
 
 pub fn init(jni: android.jni.JNI, class: android.jobject) Self {
-    // const native_invocation_handler_buffer = @embedFile("NativeInvocationHandler.dex");
-    // TODO: define class is not implemented on android
-    // const NativeInvocationHandler = jni.invokeJni(.DefineClass, .{ "NativeInvocationHandler", class_loader, @ptrCast([*]const i8, &native_invocation_handler_buffer), native_invocation_handler_buffer.len });
-    // const NativeInvocationHandler = jni.findClass("NativeInvocationHandler");
-    // const NativeInvocationHandler = jni.findClass("net/random_projects/zig_android_template/NativeInvocationHandler");
     const methods = [_]android.JNINativeMethod{
         .{
             .name = "invoke0",

--- a/src/native-invocation-handler.zig
+++ b/src/native-invocation-handler.zig
@@ -17,7 +17,7 @@ pub fn init(jni: android.JNI, class: android.jobject) Self {
     };
 }
 
-pub fn createAlloc(self: Self, jni: android.JNI, alloc: std.mem.Allocator, pointer: ?*anyopaque, function: InvokeFn) !*InvocationHandler {
+pub fn createAlloc(self: Self, jni: android.JNI, alloc: std.mem.Allocator, pointer: ?*anyopaque, function: InvokeFn) !android.jobject {
     // Create a InvocationHandler struct
     var handler = try alloc.create(InvocationHandler);
     errdefer alloc.destroy(handler);
@@ -32,9 +32,10 @@ pub fn createAlloc(self: Self, jni: android.JNI, alloc: std.mem.Allocator, point
     // Call handler constructor
     const result = jni.invokeJni(.NewObject, .{ self.class, self.initFn, handler_value }) orelse return error.InvocationHandlerInitError;
     // if (result != null) return error.InvocationHandlerInitError;
-    _ = result;
+    // _ = result;
+    return result;
 
-    return handler;
+    // return handler;
 }
 
 /// Function signature for invoke functions


### PR DESCRIPTION
This PR is a work in progress. It adds a small java class that implements an invocation handler that redirects to native methods. The invocation handler can be used to create proxy classes - that is, classes that implement a list of interfaces at runtime. There are a large number of APIs on Android that use interfaces for defining callbacks, and this allows us to use a minimal amount of java code to interface with them. 

This PR builds on #24 and adds a counter example that uses the native invocation handler to implement the callback for the button.