### PR TITLE
Some fixes for Windows

### DIFF
--- a/Sdk.zig
+++ b/Sdk.zig
@@ -956,7 +956,7 @@ pub fn signApk(sdk: Sdk, apk_file: []const u8, key_store: KeyStore) *Step {
         key_store.file,
         "--ks-pass",
         pass,
-        // omit full path on Windows to avoid problems with spaces in the path
+        // HACK: omit full path on Windows to avoid problems with spaces in the path
         if (builtin.os.tag == .windows) apk_file else sdk.b.pathFromRoot(apk_file),
         // key_store.alias,
     });

--- a/Sdk.zig
+++ b/Sdk.zig
@@ -59,6 +59,7 @@ pub fn init(b: *Builder, user_config: ?UserConfig, toolchains: ToolchainVersions
 
     const system_tools = blk: {
         const exe = if (builtin.os.tag == .windows) ".exe" else "";
+        const bat = if (builtin.os.tag == .windows) ".bat" else "";
 
         const zipalign = std.fs.path.join(b.allocator, &[_][]const u8{ actual_user_config.android_sdk_root, "build-tools", toolchains.build_tools_version, "zipalign" ++ exe }) catch unreachable;
         const aapt = std.fs.path.join(b.allocator, &[_][]const u8{ actual_user_config.android_sdk_root, "build-tools", toolchains.build_tools_version, "aapt" ++ exe }) catch unreachable;
@@ -70,7 +71,7 @@ pub fn init(b: *Builder, user_config: ?UserConfig, toolchains: ToolchainVersions
             }
             break :blk1 adb_sdk;
         };
-        const apksigner = std.fs.path.join(b.allocator, &[_][]const u8{ actual_user_config.android_sdk_root, "build-tools", toolchains.build_tools_version, "apksigner" ++ exe }) catch unreachable;
+        const apksigner = std.fs.path.join(b.allocator, &[_][]const u8{ actual_user_config.android_sdk_root, "build-tools", toolchains.build_tools_version, "apksigner" ++ bat }) catch unreachable;
         const keytool = std.fs.path.join(b.allocator, &[_][]const u8{ actual_user_config.java_home, "bin", "keytool" ++ exe }) catch unreachable;
         const javac = std.fs.path.join(b.allocator, &[_][]const u8{ actual_user_config.java_home, "bin", "javac" ++ exe }) catch unreachable;
 
@@ -955,7 +956,7 @@ pub fn signApk(sdk: Sdk, apk_file: []const u8, key_store: KeyStore) *Step {
         key_store.file,
         "--ks-pass",
         pass,
-        sdk.b.pathFromRoot(apk_file),
+        apk_file,
         // key_store.alias,
     });
     return &sign_apk.step;

--- a/Sdk.zig
+++ b/Sdk.zig
@@ -956,7 +956,8 @@ pub fn signApk(sdk: Sdk, apk_file: []const u8, key_store: KeyStore) *Step {
         key_store.file,
         "--ks-pass",
         pass,
-        apk_file,
+        // omit full path on Windows to avoid problems with spaces in the path
+        if (builtin.os.tag == .windows) apk_file else sdk.b.pathFromRoot(apk_file),
         // key_store.alias,
     });
     return &sign_apk.step;


### PR DESCRIPTION
First off, THANK YOU so much for setting all this up! Managed to replace my slightly outdated NDK+OpenGL Android app boilerplate with this quite easily by importing `Sdk.zig`.

I found 2 issues on Windows and wanted to raise a PR to at least get your thoughts. Feel free to close this or request changes or just open an issue instead and deal with it later, I'll just keep using my modified branch for now.
1. `apksigner.exe` does not seem to exist on Windows' Android SDK - rather, it is `apksigner.bat`. This should be a non-controversial fix that we can patch up.
2. `apksigner.bat` doesn't seem to like file paths with spaces. My Windows user has a space, so as a hacky solution, I changed the `sdk.b.pathFromRoot(apk_file)` argument to `apk_file` for Windows only. Might be a controversial change. Unfortunately, I can't figure out how to make this work correctly. I tried wrapping the path in quotes, and the command seems to work when I tested manually in "Command Prompt", but not in PowerShell... then I tried to figure out `cmd /C` but stumbled into [a big pile of nonsense](https://stackoverflow.com/questions/355988/how-do-i-deal-with-quote-characters-when-using-cmd-exe) so I gave up for now.